### PR TITLE
zero downtime MV

### DIFF
--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -174,3 +174,7 @@
     group by 1, 2, 3
     order by 1, 2, 3;
 {% endmacro %}
+
+{% macro risingwave__swap_mv_schema(relation, schema) -%}
+  ALTER MATERIALIZED VIEW  {{ relation }} SET SCHEMA {{ schema }};
+{%- endmacro %}

--- a/dbt/include/risingwave/macros/materializations/materialized_view.sql
+++ b/dbt/include/risingwave/macros/materializations/materialized_view.sql
@@ -9,13 +9,22 @@
                                                 database=database,
                                                 type='materialized_view') -%}
 
+<<<<<<< HEAD
   {% if full_refresh_mode and old_relation %}
     {{ adapter.drop_relation(old_relation) }}
   {% endif %}
+=======
+  {%- set tmp_relation = api.Relation.create(identifier=identifier,
+                                                schema="tmp",
+                                                database=database,
+                                                type='materializedview') -%}
+
+>>>>>>> d8b8942 (zero downtime MV)
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
+<<<<<<< HEAD
   {% if old_relation is none or (full_refresh_mode and old_relation) %}
     {% call statement('main') -%}
       {{ risingwave__create_materialized_view_as(target_relation, sql) }}
@@ -47,6 +56,24 @@
     {% endif %}
   {% endif %}
 
+=======
+  {{ adapter.drop_relation(tmp_relation) }}
+
+  {% call statement('main') -%}
+    {{ risingwave__create_materialized_view_as(tmp_relation, sql) }}
+  {%- endcall %}
+
+  {% if old_relation %}
+    {{ adapter.drop_relation(old_relation) }}
+  {% endif %}
+
+  {% set query %}
+      ALTER MATERIALIZED VIEW  {{ tmp_relation }} SET SCHEMA {{ target_relation.schema }}
+  {% endset %}
+  {% do run_query(query) %}
+
+  {{ create_indexes(target_relation) }}
+>>>>>>> d8b8942 (zero downtime MV)
   {% do persist_docs(target_relation, model) %}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}

--- a/dbt/include/risingwave/macros/materializations/materialized_view.sql
+++ b/dbt/include/risingwave/macros/materializations/materialized_view.sql
@@ -2,7 +2,9 @@
   {%- set identifier = model['alias'] -%}
   {%- set full_refresh_mode = should_full_refresh() -%}
 
-  {{ adapter.create_schema(api.Relation.create(database=database, schema="__risingwave_dbt_tmp")) }}
+  {%- set user = env_var("USER") -%}
+
+  {{ adapter.create_schema(api.Relation.create(database=database, schema=user+"__risingwave_dbt_tmp")) }}
 
   {%- set old_relation = adapter.get_relation(identifier=identifier,
                                               schema=schema,
@@ -20,7 +22,7 @@
 #}
 
   {%- set tmp_relation = api.Relation.create(identifier=identifier,
-                                                schema="__risingwave_dbt_tmp",
+                                                schema=user+"__risingwave_dbt_tmp",
                                                 database=database,
                                                 type='materialized_view') -%}
 
@@ -30,7 +32,7 @@
   {% if full_refresh_mode %}
     {{ adapter.drop_relation(tmp_relation) }}
     {% call statement('main') -%}      
-      {{ risingwave__create_materialized_view_as(tmp_relation, sql | replace(schema, "__risingwave_dbt_tmp")) }}
+      {{ risingwave__create_materialized_view_as(tmp_relation, sql | replace(schema, user+"__risingwave_dbt_tmp")) }}
     {%- endcall %}
 
     {{ create_indexes(tmp_relation) }}

--- a/dbt/include/risingwave/macros/materializations/materialized_view.sql
+++ b/dbt/include/risingwave/macros/materializations/materialized_view.sql
@@ -1,6 +1,7 @@
 {% materialization materialized_view, adapter='risingwave' %}
   {%- set identifier = model['alias'] -%}
   {%- set full_refresh_mode = should_full_refresh() -%}
+  {{ adapter.create_schema(api.Relation.create(database=database, schema="__risingwave_dbt_tmp")) }}
   {%- set old_relation = adapter.get_relation(identifier=identifier,
                                               schema=schema,
                                               database=database) -%}
@@ -9,22 +10,18 @@
                                                 database=database,
                                                 type='materialized_view') -%}
 
-<<<<<<< HEAD
   {% if full_refresh_mode and old_relation %}
     {{ adapter.drop_relation(old_relation) }}
   {% endif %}
-=======
   {%- set tmp_relation = api.Relation.create(identifier=identifier,
-                                                schema="tmp",
+                                                schema="__risingwave_dbt_tmp",
                                                 database=database,
                                                 type='materializedview') -%}
 
->>>>>>> d8b8942 (zero downtime MV)
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-<<<<<<< HEAD
   {% if old_relation is none or (full_refresh_mode and old_relation) %}
     {% call statement('main') -%}
       {{ risingwave__create_materialized_view_as(target_relation, sql) }}
@@ -56,7 +53,6 @@
     {% endif %}
   {% endif %}
 
-=======
   {{ adapter.drop_relation(tmp_relation) }}
 
   {% call statement('main') -%}
@@ -73,7 +69,6 @@
   {% do run_query(query) %}
 
   {{ create_indexes(target_relation) }}
->>>>>>> d8b8942 (zero downtime MV)
   {% do persist_docs(target_relation, model) %}
 
   {{ run_hooks(post_hooks, inside_transaction=False) }}


### PR DESCRIPTION
Hey, would be nice to avoid the initial `drop_relation` in materialized views so data isn't unavailable during mv-rebuild.

This is just a pattern proposal that builds the MV in a `tmp`-schema and then does a drop + rename to achieve minimal data downtime. 