### PR TITLE
[DAA-1305]: index update hack

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,53 +3,51 @@
 # TODO: remove global exclusion of tests when testing overhaul is complete
 exclude: "^tests/.*"
 
-
 default_language_version:
-  python: python3.8
+  python: python3.10
 
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
-  hooks:
-  - id: check-yaml
-    args: [--unsafe]
-  - id: check-json
-  - id: end-of-file-fixer
-  - id: trailing-whitespace
-  - id: check-case-conflict
-- repo: https://github.com/psf/black
-  rev: 22.3.0
-  hooks:
-  - id: black
-    args:
-    - "--line-length=99"
-    - "--target-version=py38"
-  - id: black
-    alias: black-check
-    stages: [manual]
-    args:
-    - "--line-length=99"
-    - "--target-version=py38"
-    - "--check"
-    - "--diff"
-- repo: https://github.com/pycqa/flake8
-  rev: 4.0.1
-  hooks:
-  - id: flake8
-  - id: flake8
-    alias: flake8-check
-    stages: [manual]
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.782
-  hooks:
-  - id: mypy
-    args: [--show-error-codes, --ignore-missing-imports]
-    files: ^dbt/adapters/.*
-    language: system
-  - id: mypy
-    alias: mypy-check
-    stages: [manual]
-    args: [--show-error-codes, --pretty, --ignore-missing-imports]
-    files: ^dbt/adapters
-    language: system
-
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: check-yaml
+        args: [--unsafe]
+      - id: check-json
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-case-conflict
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        args:
+          - "--line-length=99"
+          - "--target-version=py38"
+      - id: black
+        alias: black-check
+        stages: [manual]
+        args:
+          - "--line-length=99"
+          - "--target-version=py38"
+          - "--check"
+          - "--diff"
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+      - id: flake8
+        alias: flake8-check
+        stages: [manual]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.782
+    hooks:
+      - id: mypy
+        args: [--show-error-codes, --ignore-missing-imports]
+        files: ^dbt/adapters/.*
+        language: system
+      - id: mypy
+        alias: mypy-check
+        stages: [manual]
+        args: [--show-error-codes, --pretty, --ignore-missing-imports]
+        files: ^dbt/adapters
+        language: system

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -2,50 +2,43 @@
 -- But materialize verison includes 'index' type.
 -- Here we only query table, view, materialized view and source. (without index and SINK)
 {% macro risingwave__list_relations_without_caching(schema_relation) %}
-  {% call statement('list_relations_without_caching', fetch_result=True) -%}
-    select 
-    '{{ schema_relation.database }}' as database,
-    rw_relations.name as name,
-    rw_schemas.name as schema,
-    CASE WHEN relation_type = 'materialized view' THEN
-      'materialized_view'
-      else relation_type
-    END AS type
-    from rw_relations join rw_schemas on schema_id=rw_schemas.id
-    where rw_schemas.name not in ('rw_catalog', 'information_schema', 'pg_catalog')
-    and relation_type in ('table', 'view', 'source', 'sink', 'materialized view', 'index')
-    AND rw_schemas.name = '{{ schema_relation.schema }}'
-  {% endcall %}
-  {{ return(load_result('list_relations_without_caching').table) }}
+    {% call statement("list_relations_without_caching", fetch_result=True) -%}
+        select
+            '{{ schema_relation.database }}' as database,
+            rw_relations.name as name,
+            rw_schemas.name as schema,
+            case when relation_type = 'materialized view' then 'materialized_view' else relation_type end as type
+        from rw_relations
+        join rw_schemas on schema_id = rw_schemas.id
+        where
+            rw_schemas.name not in ('rw_catalog', 'information_schema', 'pg_catalog')
+            and relation_type in ('table', 'view', 'source', 'sink', 'materialized view', 'index')
+            and rw_schemas.name = '{{ schema_relation.schema }}'
+    {% endcall %}
+    {{ return(load_result("list_relations_without_caching").table) }}
 {% endmacro %}
 
 {% macro risingwave__get_columns_in_relation(relation) -%}
-  {% call statement('get_columns_in_relation', fetch_result=True) %}
-      select
-          column_name,
-          data_type,
-          null as character_maximum_length,
-          null as numeric_precision,
-          null as numeric_scale
+    {% call statement("get_columns_in_relation", fetch_result=True) %}
+        select
+            column_name, data_type, null as character_maximum_length, null as numeric_precision, null as numeric_scale
 
-      from {{ relation.information_schema('columns') }}
-      where table_name = '{{ relation.identifier }}'
-        {% if relation.schema %}
-        and table_schema = '{{ relation.schema }}'
-        {% endif %}
-      order by ordinal_position
+        from {{ relation.information_schema("columns") }}
+        where
+            table_name = '{{ relation.identifier }}'
+            {% if relation.schema %} and table_schema = '{{ relation.schema }}' {% endif %}
+        order by ordinal_position
 
-  {% endcall %}
-  {% set table = load_result('get_columns_in_relation').table %}
-  {{ return(sql_convert_columns_in_relation(table)) }}
+    {% endcall %}
+    {% set table = load_result("get_columns_in_relation").table %}
+    {{ return(sql_convert_columns_in_relation(table)) }}
 {% endmacro %}
 
 
 -- temporary disable temp table for lacking support to rename table
 {% macro risingwave__make_temp_relation(base_relation, suffix) %}
     {%- set temp_identifier = base_relation.identifier -%}
-    {%- set temp_relation = base_relation.incorporate(
-                                path={"identifier": temp_identifier}) -%}
+    {%- set temp_relation = base_relation.incorporate(path={"identifier": temp_identifier}) -%}
 
     {{ return(temp_relation) }}
 {% endmacro %}
@@ -55,9 +48,9 @@
 {% endmacro %}
 
 {% macro risingwave__get_create_index_sql(relation, index_dict) -%}
-  {%- set index_config = adapter.parse_index(index_dict) -%}
-  {%- set comma_separated_columns = ", ".join(index_config.columns) -%}
-  {%- set index_name = "__dbt_index_" + relation.identifier + "_" + "_".join(index_config.columns) -%}
+    {%- set index_config = adapter.parse_index(index_dict) -%}
+    {%- set comma_separated_columns = ", ".join(index_config.columns) -%}
+    {%- set index_name = "__dbt_index_" + relation.identifier + "_" + "_".join(index_config.columns) -%}
 
   create index if not exists
   "{{ index_name }}"
@@ -65,23 +58,34 @@
   ({{ comma_separated_columns }});
 {%- endmacro %}
 
+{% macro risingwave__get_create_index_sql2(relation, index_name, comma_separated_columns) -%}
+  create index if not exists
+  "{{ index_name }}"
+  on {{ relation }}
+  ({{ comma_separated_columns }});
+{%- endmacro %}
+
 {%- macro risingwave__get_drop_index_sql(relation, index_name) -%}
     drop index if exists "{{ relation.schema }}"."{{ index_name }}"
 {%- endmacro -%}
 
+{%- macro risingwave__get_drop_index_sql2(relation, index_name) -%}
+    drop index if exists "{{ relation.schema }}"."{{ index_name }}";
+{%- endmacro -%}
+
 {% macro risingwave__drop_relation(relation) -%}
-  {% call statement('drop_relation') -%}
-    {% if relation.type == 'view' %}
+    {% call statement("drop_relation") -%}
+        {% if relation.type == "view" %}
       drop view if exists {{ relation }} cascade
-    {% elif relation.type == 'table' %}
+        {% elif relation.type == "table" %}
       drop table if exists {{ relation }} cascade
-    {% elif relation.type == 'materializedview' %}
+        {% elif relation.type == "materializedview" %}
       drop materialized view if exists {{ relation }} cascade
-    {% elif relation.type == 'materialized_view' %}
+        {% elif relation.type == "materialized_view" %}
       drop materialized view if exists {{ relation }} cascade
-    {% elif relation.type == 'source' %}
+        {% elif relation.type == "source" %}
       drop source if exists {{ relation }} cascade
-    {% elif relation.type == 'sink' %}
+        {% elif relation.type == "sink" %}
       drop sink if exists {{ relation }} cascade
     {% endif %}
   {%- endcall %}
@@ -121,65 +125,62 @@
 {%- endmacro %}
 
 {% macro risingwave__run_sql(sql) -%}
-  {% set contract_config = config.get('contract') %}
-  {% if contract_config.enforced %}
-    {{exceptions.warn("Model contracts cannot be enforced for source, table_with_connector and sink")}}
-  {%- endif %}
-  {{ sql }};
+    {% set contract_config = config.get("contract") %}
+    {% if contract_config.enforced %}
+        {{ exceptions.warn("Model contracts cannot be enforced for source, table_with_connector and sink") }}
+    {%- endif %}
+    {{ sql }}
+    ;
 {%- endmacro %}
 
 {%- macro risingwave__update_indexes_on_materialized_view(relation, index_changes) -%}
-    {{- log("Applying UPDATE INDEXES to: " ~ relation) -}}
+    {%- set indexes = config.get("indexes") -%}
+    {{- log("Applying UPDATE INDEXES to: " ~ relation ~ " using indexes:" ~ indexes | join("\n")) -}}
 
-    {%- for _index_change in index_changes -%}
-        {%- set _index = _index_change.context -%}
+    {%- if not indexes -%} {{ risingwave__execute_no_op(relation) }} {%- endif -%}
 
-        {%- if _index_change.action == "drop" -%}
+    -- hacky solution to come around RW not having idempotency on `CREATE`
+    -- `[IF NOT EXIST]` for indexes in custom schemas (i.e. not in 'public').
+    {%- for _index in indexes -%}
+        {%- set comma_separated_columns = ", ".join(_index.columns) -%}
+        {%- set _index_name = "__dbt_index_" + relation.identifier + "_" + "_".join(_index.columns) -%}
 
-            {{ risingwave__get_drop_index_sql(relation, _index.name) }};
+        -- drop index
+        {{ risingwave__get_drop_index_sql2(relation, _index_name) }}
 
-        {%- elif _index_change.action == "create" -%}
-
-            {{ risingwave__get_create_index_sql(relation, _index.as_node_config) }}
-
-        {%- endif -%}
+        -- create index
+        {{ risingwave__get_create_index_sql2(relation, _index_name, comma_separated_columns) }}
 
     {%- endfor -%}
-
 {%- endmacro -%}
 
 {% macro risingwave__get_show_indexes_sql(relation) %}
-    with index_info as (
-    select
-        i.relname                                   as name,
-        'btree'                                     as method,
-        ix.indisunique                              as "unique",
-        a.attname                                   as attname,
-        array_position(ix.indkey, a.attnum)        as ord
-    from pg_index ix
-    join pg_class i
-        on i.oid = ix.indexrelid
-    join pg_class t
-        on t.oid = ix.indrelid
-    join pg_namespace n
-        on n.oid = t.relnamespace
-    join pg_attribute a
-        on a.attrelid = t.oid
-        and a.attnum = ANY(ix.indkey)
-    where t.relname = '{{ relation.identifier }}'
-      and n.nspname = '{{ relation.schema }}'
-      and t.relkind in ('r', 'm')
-    )
-    select name, method, "unique", array_to_string(array_agg(attname order by ord), ',') as column_names from index_info
+    with
+        index_info as (
+            select
+                i.relname as name,
+                'btree' as method,
+                ix.indisunique as "unique",
+                a.attname as attname,
+                array_position(ix.indkey, a.attnum) as ord
+            from pg_index ix
+            join pg_class i on i.oid = ix.indexrelid
+            join pg_class t on t.oid = ix.indrelid
+            join pg_namespace n on n.oid = t.relnamespace
+            join pg_attribute a on a.attrelid = t.oid and a.attnum = any(ix.indkey)
+            where
+                t.relname = '{{ relation.identifier }}'
+                and n.nspname = '{{ relation.schema }}'
+                and t.relkind in ('r', 'm')
+        )
+    select name, method, "unique", array_to_string(array_agg(attname order by ord), ',') as column_names
+    from index_info
     group by 1, 2, 3
-    order by 1, 2, 3;
+    order by 1, 2, 3
+    ;
 {% endmacro %}
 
 {% macro risingwave__execute_no_op(target_relation) %}
-    {% do store_raw_result(
-        name="main",
-        message="skip " ~ target_relation,
-        code="skip",
-        rows_affected="-1"
-    ) %}
+    {% do store_raw_result(name="main", message="skip " ~ target_relation, code="skip", rows_affected="-1") %}
 {% endmacro %}
+

--- a/dbt/include/risingwave/macros/materializations/materialized_view.sql
+++ b/dbt/include/risingwave/macros/materializations/materialized_view.sql
@@ -1,23 +1,38 @@
 {% materialization materialized_view, adapter='risingwave' %}
   {%- set identifier = model['alias'] -%}
   {%- set full_refresh_mode = should_full_refresh() -%}
+
+  {%- set user = env_var("USER") -%}
+
+  {{ adapter.create_schema(api.Relation.create(database=database, schema=user+"__risingwave_dbt_tmp")) }}
+
   {%- set old_relation = adapter.get_relation(identifier=identifier,
                                               schema=schema,
                                               database=database) -%}
+
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
                                                 database=database,
                                                 type='materialized_view') -%}
 
-  {% if full_refresh_mode and old_relation %}
-    {{ adapter.drop_relation(old_relation) }}
-  {% endif %}
+  {%- set tmp_relation = api.Relation.create(identifier=identifier,
+                                                schema=user+"__risingwave_dbt_tmp",
+                                                database=database,
+                                                type='materialized_view') -%}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-  {% if old_relation is none or (full_refresh_mode and old_relation) %}
-    {% call statement('main') -%}
+  {% if full_refresh_mode %}
+    {{ adapter.drop_relation(tmp_relation) }}
+    {% call statement('main') -%}      
+      {{ risingwave__create_materialized_view_as(tmp_relation, sql | replace(schema, user+"__risingwave_dbt_tmp")) }}
+    {%- endcall %}
+
+    {{ create_indexes(tmp_relation) }}
+
+  {% elif old_relation is none %}
+    {% call statement('main') -%}      
       {{ risingwave__create_materialized_view_as(target_relation, sql) }}
     {%- endcall %}
 

--- a/dbt/include/risingwave/macros/materializations/materialized_view.sql
+++ b/dbt/include/risingwave/macros/materializations/materialized_view.sql
@@ -1,72 +1,80 @@
-{% materialization materialized_view, adapter='risingwave' %}
+{% materialization materialized_view, adapter = "risingwave" %}
 
-  {%- set identifier = model['alias'] -%}
-  {%- set full_refresh_mode = should_full_refresh() -%}
+    {%- set identifier = model["alias"] -%}
+    {%- set full_refresh_mode = should_full_refresh() -%}
 
-  {%- set custom_schema = schema~"__risingwave_dbt_tmp" -%}
+    {%- set custom_schema = schema ~ "__risingwave_dbt_tmp" -%}
 
-  {{ adapter.create_schema(api.Relation.create(database=database, schema=custom_schema)) }}
+    {{ adapter.create_schema(api.Relation.create(database=database, schema=custom_schema)) }}
 
-  {%- set old_relation = adapter.get_relation(identifier=identifier,
-                                              schema=schema,
-                                              database=database) -%}
+    {%- set old_relation = adapter.get_relation(identifier=identifier, schema=schema, database=database) -%}
 
-  {%- set target_relation = api.Relation.create(identifier=identifier,
-                                                schema=schema,
-                                                database=database,
-                                                type='materialized_view') -%}
+    {%- set target_relation = api.Relation.create(
+        identifier=identifier, schema=schema, database=database, type="materialized_view"
+    ) -%}
 
-  {%- set tmp_relation = api.Relation.create(identifier=identifier,
-                                                schema=custom_schema,
-                                                database=database,
-                                                type='materialized_view') -%}
+    {%- set tmp_relation = api.Relation.create(
+        identifier=identifier, schema=custom_schema, database=database, type="materialized_view"
+    ) -%}
 
-  {{ run_hooks(pre_hooks, inside_transaction=False) }}
-  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+    {{ run_hooks(pre_hooks, inside_transaction=False) }}
+    {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-  {% if full_refresh_mode %}
-    {{ adapter.drop_relation(tmp_relation) }}
-    {% call statement('main') -%}      
-      {{ risingwave__create_materialized_view_as(tmp_relation, sql | replace(schema, custom_schema)) }}
-    {%- endcall %}
+    {% if full_refresh_mode %}
+        {{ adapter.drop_relation(tmp_relation) }}
+        {% call statement("main") -%}
+            {{ risingwave__create_materialized_view_as(tmp_relation, sql | replace(schema, custom_schema)) }}
+        {%- endcall %}
 
-    {{ create_indexes(tmp_relation) }}
+        {{ create_indexes(tmp_relation) }}
 
-  {% elif old_relation is none %}
-    {% call statement('main') -%}      
-      {{ risingwave__create_materialized_view_as(target_relation, sql) }}
-    {%- endcall %}
+    {% elif old_relation is none %}
+        {% call statement("main") -%} {{ risingwave__create_materialized_view_as(target_relation, sql) }}
+        {%- endcall %}
 
-    {{ create_indexes(target_relation) }}
-  {% else %}
-    -- get config options
-    {% set on_configuration_change = config.get('on_configuration_change') %}
-    {% set configuration_changes = get_materialized_view_configuration_changes(old_relation, config) %}
-
-    {% if configuration_changes is none %}
-      -- do nothing
-      {{ materialized_view_execute_no_op(target_relation) }}
-    {% elif on_configuration_change == 'apply' %}
-      {% call statement('main') -%}
-        {{ risingwave__update_indexes_on_materialized_view(target_relation, configuration_changes.indexes) }}
-      {%- endcall %}
-    {% elif on_configuration_change == 'continue' %}
-        -- do nothing but a warn
-        {{ exceptions.warn("Configuration changes were identified and `on_configuration_change` was set to `continue` for `" ~ target_relation ~ "`") }}
-        {{ materialized_view_execute_no_op(target_relation) }}
-    {% elif on_configuration_change == 'fail' %}
-        {{ exceptions.raise_fail_fast_error("Configuration changes were identified and `on_configuration_change` was set to `fail` for `" ~ target_relation ~ "`") }}
+        {{ create_indexes(target_relation) }}
     {% else %}
-        -- this only happens if the user provides a value other than `apply`, 'continue', 'fail'
-        {{ exceptions.raise_compiler_error("Unexpected configuration scenario") }}
+        -- get config options
+        {% set on_configuration_change = config.get("on_configuration_change") %}
+        {% set configuration_changes = get_materialized_view_configuration_changes(old_relation, config) %}
 
+        {% if configuration_changes is none %}
+            -- do nothing
+            {{ materialized_view_execute_no_op(target_relation) }}
+        {% elif on_configuration_change == "apply" %}
+            {% call statement("main") -%}
+                {{ risingwave__update_indexes_on_materialized_view(target_relation, configuration_changes.indexes) }}
+            {%- endcall %}
+        {% elif on_configuration_change == "continue" %}
+            -- do nothing but a warn
+            {{
+                exceptions.warn(
+                    "Configuration changes were identified and `on_configuration_change` was set to `continue` for `"
+                    ~ target_relation
+                    ~ "`"
+                )
+            }}
+            {{ materialized_view_execute_no_op(target_relation) }}
+        {% elif on_configuration_change == "fail" %}
+            {{
+                exceptions.raise_fail_fast_error(
+                    "Configuration changes were identified and `on_configuration_change` was set to `fail` for `"
+                    ~ target_relation
+                    ~ "`"
+                )
+            }}
+        {% else %}
+            -- this only happens if the user provides a value other than `apply`, 'continue', 'fail'
+            {{ exceptions.raise_compiler_error("Unexpected configuration scenario") }}
+
+        {% endif %}
     {% endif %}
-  {% endif %}
 
-  {% do persist_docs(target_relation, model) %}
+    {% do persist_docs(target_relation, model) %}
 
-  {{ run_hooks(post_hooks, inside_transaction=False) }}
-  {{ run_hooks(post_hooks, inside_transaction=True) }}
+    {{ run_hooks(post_hooks, inside_transaction=False) }}
+    {{ run_hooks(post_hooks, inside_transaction=True) }}
 
-  {{ return({'relations': [target_relation]}) }}
+    {{ return({"relations": [target_relation]}) }}
 {% endmaterialization %}
+


### PR DESCRIPTION
A hack needed because RW doesn't have `[IF NOT EXISTS]` idempotency on `CREATE INDEX` for indexes that are not in the default_schema (=`public`). See issue https://github.com/risingwavelabs/risingwave/issues/15195

Furthermore, the dbt-postgres adapter doesn't resolve multi-index columns very well. See PR to fix that here https://github.com/dbt-labs/dbt-postgres/pull/22/files.

The issue with dbt-postgres adapter is that it loads in the `index_columns` as a `set` or `frozenset` and ergo loses its ordering. In dbt-risingwave we are dependent on the ordering of the indexes because they are used as prefixes in the index tables.

To come around this, luckily dropping indexes support `[IF EXISTS]` clause, so we do the following:

- read the indexes explicit from `config`
- `DROP` first, then `CREATE` for all indexes in config