### PR TITLE
refactor: on_configuration_change default to continue

### DIFF
--- a/dbt/include/risingwave/macros/materializations/materialized_view.sql
+++ b/dbt/include/risingwave/macros/materializations/materialized_view.sql
@@ -24,7 +24,7 @@
     {{ create_indexes(target_relation) }}
   {% else %}
     -- get config options
-    {% set on_configuration_change = config.get('on_configuration_change') %}
+    {% set on_configuration_change = config.get('on_configuration_change', "continue") %}
     {% set configuration_changes = get_materialized_view_configuration_changes(old_relation, config) %}
 
     {% if configuration_changes is none %}

--- a/dbt/include/risingwave/macros/materializations/materializedview.sql
+++ b/dbt/include/risingwave/macros/materializations/materializedview.sql
@@ -24,7 +24,7 @@
     {{ create_indexes(target_relation) }}
   {% else %}
     -- get config options
-    {% set on_configuration_change = config.get('on_configuration_change') %}
+    {% set on_configuration_change = config.get('on_configuration_change', "continue") %}
     {% set configuration_changes = get_materialized_view_configuration_changes(old_relation, config) %}
 
     {% if configuration_changes is none %}


### PR DESCRIPTION
Suggestion to have the default values for index creation to be `continue` rather than `apply`.
Docs: https://docs.getdbt.com/reference/resource-configs/on_configuration_change

According to the docs, if the `on_configuration_change` is not provided -> it defaults to `apply`. Perhaps this works well for other adapters, e.g. redshift, postgres, etc, for how their materialized view works but to me it feels like this is something we don't want for Risingwave.

Scenario:
I've already built a model for the first time using 
```shell 
dbt run -s <my-model>
```
If I run this command, again after creating it the first time, the model creation is "skipped" (because already exist) but the indexes creation are not skipped (if indexes are specified). I would expect the indexes to be skipped as well in this case if the `on_configuration_change` is by default empty. 