### PR TITLE
feat: sink configuration

### DIFF
--- a/dbt/adapters/risingwave/__init__.py
+++ b/dbt/adapters/risingwave/__init__.py
@@ -1,14 +1,15 @@
-from dbt.adapters.risingwave.connections import RisingWaveConnectionManager # noqa
-from dbt.adapters.risingwave.connections import RisingWaveCredentials
-from dbt.adapters.risingwave.impl import RisingWaveAdapter
-
 from dbt.adapters.base import AdapterPlugin
+
+from dbt.adapters.risingwave.connections import (  # noqa: F401
+    RisingWaveConnectionManager,
+    RisingWaveCredentials,
+)
+from dbt.adapters.risingwave.impl import RisingWaveAdapter
 from dbt.include import risingwave
 
-
 Plugin = AdapterPlugin(
-    adapter=RisingWaveAdapter,
+    adapter=RisingWaveAdapter,  # type: ignore
     credentials=RisingWaveCredentials,
     include_path=risingwave.PACKAGE_PATH,
     dependencies=["postgres"],
-    )
+)

--- a/dbt/adapters/risingwave/impl.py
+++ b/dbt/adapters/risingwave/impl.py
@@ -1,17 +1,16 @@
+from dbt.adapters.postgres.impl import PostgresAdapter
 
-from typing import Optional, List
-from dbt.adapters.sql import SQLAdapter as adapter_cls
-from dbt.adapters.base.relation import BaseRelation 
-from dbt.adapters.risingwave import RisingWaveConnectionManager
+from dbt.adapters.risingwave.connections import RisingWaveConnectionManager
 from dbt.adapters.risingwave.relation import RisingWaveRelation
-from dbt.adapters.postgres import PostgresAdapter
 
 
 class RisingWaveAdapter(PostgresAdapter):
     ConnectionManager = RisingWaveConnectionManager
-    Relation = RisingWaveRelation
-    def rename_relation(self, from_relation , to_relation ) -> None:
-        pass
+    Relation = RisingWaveRelation  # type: ignore
+
+    def rename_relation(self, from_relation, to_relation) -> None:
+        raise NotImplementedError("RisingWave does not support renaming relations yet")
+
     def _link_cached_relations(self, manifest):
         # lack of `pg_depend`, `pg_rewrite`
         pass

--- a/dbt/adapters/risingwave/relation.py
+++ b/dbt/adapters/risingwave/relation.py
@@ -1,27 +1,22 @@
 from dataclasses import dataclass
 from typing import Optional, Type
 
-from dbt.adapters.postgres import PostgresRelation
-from dbt.dataclass_schema import StrEnum
+from dbt.adapters.postgres.relation import PostgresRelation
+from dbt.adapters.relation_configs.config_base import RelationConfigBase
+from dbt.contracts.graph.nodes import ModelNode
+from dbt.exceptions import DbtRuntimeError
 from dbt.utils import classproperty
 
-
-class RisingWaveRelationType(StrEnum):
-    Table = "table"
-    View = "view"
-    CTE = "cte"
-    MaterializedView = "materialized_view"
-    MaterializedView_v1_5_0 = "materializedview"
-    External = "external"
-
-    Source = "source"
-    Sink = "sink"
+from dbt.adapters.risingwave.relation_configs.base import RisingWaveRelationType
+from dbt.adapters.risingwave.relation_configs.sink import RisingWaveSinkConfig
 
 
 @dataclass(frozen=True, eq=False, repr=False)
 class RisingWaveRelation(PostgresRelation):
-    type: Optional[RisingWaveRelationType] = None
-
+    type: Optional[RisingWaveRelationType] = None  # type: ignore
+    relation_configs = {
+        RisingWaveRelationType.Sink.value: RisingWaveSinkConfig,
+    }
 
     @classproperty
     def get_relation_type(cls) -> Type[RisingWaveRelationType]:
@@ -31,3 +26,11 @@ class RisingWaveRelation(PostgresRelation):
     # We set a relatively large value right now.
     def relation_max_name_length(self):
         return 1024
+
+    @classmethod
+    def from_config(cls, config: ModelNode) -> RelationConfigBase:
+        relation_type: str = config.config.materialized  # type: ignore
+
+        if rel_configs := cls.relation_configs.get(relation_type):
+            return rel_configs.from_relation_config(config)
+        raise DbtRuntimeError("from_config() is not supported for relation type:", relation_type)

--- a/dbt/adapters/risingwave/relation_configs/base.py
+++ b/dbt/adapters/risingwave/relation_configs/base.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from dbt.adapters.relation_configs.config_base import RelationConfigBase
+from dbt.contracts.graph.nodes import ModelNode
+from dbt.dataclass_schema import StrEnum
+from dbt_common.exceptions import NotImplementedError
+
+
+class RisingWaveRelationType(StrEnum):
+    """
+    Enumeration of the RisingWave relation types.
+    """
+
+    Table = "table"
+    View = "view"
+    CTE = "cte"
+    MaterializedView = "materialized_view"
+    MaterializedView_v1_5_0 = "materializedview"
+    External = "external"
+
+    Source = "source"
+    Sink = "sink"
+
+
+@dataclass(frozen=True, eq=False, repr=False)
+class RisingWaveRelationConfigBase(RelationConfigBase):
+    """
+    Extension of the RelationConfigBase class to include the RisingWave relation types.
+    """
+
+    @classmethod
+    def from_relation_config(cls, relation_config: ModelNode) -> RisingWaveRelationConfigBase:
+        relation_config_dict = cls.parse_relation_config(relation_config)
+        relation = cls.from_dict(relation_config_dict)
+        return relation  # type: ignore
+
+    @classmethod
+    def parse_relation_config(cls, _: ModelNode) -> Dict:
+        raise NotImplementedError(
+            "`parse_relation_config()` needs to be implemented on this RisingWaveRelationConfigBase instance"
+        )

--- a/dbt/adapters/risingwave/relation_configs/sink.py
+++ b/dbt/adapters/risingwave/relation_configs/sink.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from dbt.adapters.relation_configs import RelationConfigValidationMixin
+from dbt.contracts.graph.nodes import ModelNode
+from dbt_common.exceptions import CompilationError
+
+from dbt.adapters.risingwave.relation_configs.base import (
+    RisingWaveRelationConfigBase,
+)
+
+
+@dataclass(frozen=True, eq=True, unsafe_hash=True)
+class RisingWaveSinkConfig(
+    RisingWaveRelationConfigBase,
+    RelationConfigValidationMixin,
+):
+    """
+    Dataclass for the RisingWave sink relation configuration.
+    """
+
+    connector: str
+    data_format: Optional[str] = None
+    data_encode: Optional[str] = None
+    sink_values: Dict = field(default_factory=dict)
+    format_values: Dict = field(default_factory=dict)
+
+    @classmethod
+    def parse_relation_config(cls, relation_config: ModelNode) -> Dict:
+        """
+        Constructor method to parse the relation_config.
+
+        Parameters
+        ----------
+        relation_config : ModelNode
+            The relation_config to parse. Used via e.g. `config.model`.
+
+        Returns
+        -------
+        Dict
+            The parsed relation_config as a dictionary.
+        """
+
+        if not (connector := relation_config.config.get("connector")):
+            raise CompilationError(f"got connector='{connector}', required.")
+        if not (sink_values := relation_config.config.get("sink_values")):
+            raise CompilationError(f"got sink_values='{sink_values}', required.")
+
+        return {
+            "connector": connector,
+            "data_format": relation_config.config.get("data_format"),
+            "data_encode": relation_config.config.get("data_encode"),
+            "sink_values": sink_values,
+            "format_values": relation_config.config.get("format_values"),
+        }
+
+    @property
+    def with_statement(self) -> str:
+        """
+        Construct the `WITH` statement for the relation.
+
+        Returns
+        -------
+        str
+            The `WITH` statement for the relation.
+        """
+        builder = f"""
+        connector = '{self.connector}',
+        """
+
+        for k, v in self.sink_values.items():
+            if not v:
+                continue
+            builder += f"{k} = '{v}',\n"
+        return builder[:-2]
+
+    @property
+    def has_format_values(self) -> bool:
+        """
+        Whether the user specified format encoding and format values.
+
+        Returns
+        -------
+        bool
+            Whether the user specified format encoding and format values.
+        """
+        return len(self.format_values) > 0 and bool(self.data_format) and bool(self.data_encode)
+
+    @property
+    def format_parameters(self) -> str:
+        """
+        Construct the format parameters for the relation.
+
+        Returns
+        -------
+        str
+            The format parameters for the relation.
+        """
+        if not self.has_format_values:
+            return ""
+        builder = ""
+        for k, v in self.format_values.items():
+            if not v:
+                continue
+            builder += f"{k} = '{v}',\n"
+        return builder[:-2]

--- a/dbt/include/risingwave/macros/materializations/sink.sql
+++ b/dbt/include/risingwave/macros/materializations/sink.sql
@@ -1,33 +1,44 @@
-{% materialization sink, adapter='risingwave' %}
-  {%- set identifier = model['alias'] -%}
-  {%- set full_refresh_mode = should_full_refresh() -%}
-  {%- set old_relation = adapter.get_relation(identifier=identifier,
-                                              schema=schema,
-                                              database=database) -%}
-  {%- set target_relation = api.Relation.create(identifier=identifier,
-                                                schema=schema,
-                                                database=database,
-                                                type='sink') -%}
+{% materialization sink, adapter = "risingwave" %}
+    {%- set identifier = model["alias"] -%}
+    {%- set full_refresh_mode = should_full_refresh() -%}
+    {%- set old_relation = adapter.get_relation(
+        identifier=identifier,
+        schema=schema,
+        database=database,
+    ) -%}
+    {%- set target_relation = api.Relation.create(
+        identifier=identifier,
+        schema=schema,
+        database=database,
+        type="sink",
+    ) -%}
 
-  {% if full_refresh_mode and old_relation %}
-    {{ adapter.drop_relation(old_relation) }}
-  {% endif %}
+    {% if full_refresh_mode and old_relation %}
+      {{ adapter.drop_relation(old_relation) }}
+    {% endif %}
 
-  {{ run_hooks(pre_hooks, inside_transaction=False) }}
-  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+    {{ run_hooks(pre_hooks, inside_transaction=False) }}
+    {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-  {% if old_relation is none or (full_refresh_mode and old_relation) %}
-    {% call statement('main') -%}
-      {{ risingwave__run_sql(sql) }}
-    {%- endcall %}
-  {% else %}
-    {{ risingwave__execute_no_op(target_relation) }}
-  {% endif %}
+    {% if old_relation is none or (full_refresh_mode and old_relation) %}
+        {%- set raw_sql_bool = config.get("raw_sql") -%}
 
-  {% do persist_docs(target_relation, model) %}
+        {% call statement("main") -%}
+            {% if not raw_sql_bool %}
+              {{ rising_wave__create_sink(target_relation, sql) }}
+            {% else %} 
+              {{ risingwave__run_sql(sql) }}
+            {% endif %}
+        {%- endcall %}
+    {% else %}
+      {{ risingwave__execute_no_op(target_relation) }}
+    {% endif %}
 
-  {{ run_hooks(post_hooks, inside_transaction=False) }}
-  {{ run_hooks(post_hooks, inside_transaction=True) }}
+    {% do persist_docs(target_relation, model) %}
 
-  {{ return({'relations': [target_relation]}) }}
+    {{ run_hooks(post_hooks, inside_transaction=False) }}
+    {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+    {{ return({"relations": [target_relation]}) }}
 {% endmaterialization %}
+

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+
 from setuptools import find_namespace_packages, setup
 
 package_name = "dbt-risingwave"
@@ -23,5 +24,5 @@ setup(
     url="https://github.com/risingwavelabs/dbt-risingwave",
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
-    install_requires=["dbt-postgres~=1.7.0"],
+    install_requires=["dbt-postgres~=1.7.0", "dbt-common<1.0"],
 )


### PR DESCRIPTION
**note:** opening as draft for early-review. Need to fix the following:
- [ ] add tests for the changes
- [ ] update config for all sink adapters

--- 

# What has changed:
Suggestion on making the dbt adapter a bit more "risingwave specific" by utilising relation configuration than creating the raw sql code in the dbt models. There is still an option to use raw sql by specifying `raw_sql=true´ in config.

- add base `RisingWaveRelationConfigBase` class containing the properties/methods needed for _any_ relation configuration (sink, mw, source, etc).
- raise error if users try to `rename_relation` instead of silently `pass`
- add base `RisingWaveSinkConfiguration` class containing the properties/methods needed for any sink adapter. Handles look up to their own adapter based on connector.
- updated `risingwave__create_sink` macro if user want to use the "dbt" version of things
- updated some code to conform with the current `pre-commit` style of things.


Example of model looking like:

```sql
{{
    config(
        materialized="sink",
        connector="kinesis",
        data_format="PLAIN",
        force_append_only=true,
        primary_key="id,sk",
        region="us-east-1"
        stream="kinesis-stream-name"
        role_arn="arn:aws:iam::123456789012:role/stream-role-arn"
        access_key_id=env_var("AWS_ACCESS_KEY_ID"),
        secret_access_key=env_var("AWS_SECRET_ACCESS_KEY"),
    )
}}

select pk as id, sk
from {{ ref("interim_model") }}
```
