### PR TITLE
chore: update dev-requirements with latest dbt-labs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,8 @@
 # install latest changes in dbt-core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-tests-adapter&subdirectory=tests/adapter
+git+https://github.com/dbt-labs/dbt-core.git@main#subdirectory=core
+git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-tests-adapter
+git+https://github.com/dbt-labs/dbt-common.git@main
+git+https://github.com/dbt-labs/dbt-postgres.git@main
 
 black==22.3.0
 bumpversion


### PR DESCRIPTION
Update the `dev-requirements.txt` file with latest dependencies of from dbt-labs.
Consider if we want to use migrate away from `setup.py` to `pyproject.toml` with e.g. [hatch](https://hatch.pypa.io/1.9/config/build/) or [poetry](https://python-poetry.org/).