### PR TITLE
fix rename

### DIFF
--- a/dbt/adapters/risingwave/impl.py
+++ b/dbt/adapters/risingwave/impl.py
@@ -10,8 +10,6 @@ from dbt.adapters.postgres import PostgresAdapter
 class RisingWaveAdapter(PostgresAdapter):
     ConnectionManager = RisingWaveConnectionManager
     Relation = RisingWaveRelation
-    def rename_relation(self, from_relation , to_relation ) -> None:
-        pass
     def _link_cached_relations(self, manifest):
         # lack of `pg_depend`, `pg_rewrite`
         pass


### PR DESCRIPTION
- `incremental` model relies on `rename`, so we need to enable it.