### PR TITLE
feat: remove parentheses of mv table and view

### DIFF
--- a/dbt/adapters/risingwave/__version__.py
+++ b/dbt/adapters/risingwave/__version__.py
@@ -1,1 +1,1 @@
-version = "1.7.3"
+version = "1.7.4"

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -80,9 +80,8 @@
     {% if contract_config.enforced %}
       {{ get_assert_columns_equivalent(sql) }}
     {%- endif %}
-  as (
-    {{ sql }}
-  );
+  as {{ sql }}
+  ;
 {%- endmacro %}
 
 {% macro risingwave__create_table_as(relation, sql) -%}
@@ -91,9 +90,8 @@
     {% if contract_config.enforced %}
       {{ get_assert_columns_equivalent(sql) }}
     {%- endif %}
-  as (
-    {{ sql }}
-  );
+  as {{ sql }}
+  ;
 {%- endmacro %}
 
 {% macro risingwave__create_materialized_view_as(relation, sql) -%}
@@ -102,12 +100,11 @@
     {% if contract_config.enforced %}
       {{ get_assert_columns_equivalent(sql) }}
     {%- endif %}
-  as (
-    {{ sql }}
-  );
+  as {{ sql }}
+  ;
 {%- endmacro %}
 
-{% macro rising_wave__create_sink(relation, sql) -%}
+{% macro risingwave__create_sink(relation, sql) -%}
     {%- set _format_parameters = config.get("format_parameters") -%}
     {%- set data_format = config.get("data_format") -%}
     {%- set data_encode = config.get("data_encode") -%}

--- a/dbt/include/risingwave/macros/materializations/sink.sql
+++ b/dbt/include/risingwave/macros/materializations/sink.sql
@@ -24,7 +24,7 @@
         {%- set connector = config.get("connector") -%}
         {% call statement("main") -%}
             {% if connector %}
-              {{ rising_wave__create_sink(target_relation, sql) }}
+              {{ risingwave__create_sink(target_relation, sql) }}
             {% else %}
               {{ risingwave__run_sql(sql) }}
             {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_namespace_packages, setup
 
 package_name = "dbt-risingwave"
 # make sure this always matches dbt/adapters/{adapter}/__version__.py
-package_version = "1.7.3"
+package_version = "1.7.4"
 description = """The RisingWave adapter plugin for dbt"""
 
 with open(os.path.join(os.path.dirname(__file__), "README.md")) as f:


### PR DESCRIPTION
To support emit on window close, we need to remove parentheses from the generating query. resolve https://github.com/risingwavelabs/dbt-risingwave/issues/44