### PR TITLE
feat: Add streaming_rate_limit param option for MV creation

### DIFF
--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -96,6 +96,10 @@
 
 {% macro risingwave__create_materialized_view_as(relation, sql) -%}
   create materialized view if not exists {{ relation }}
+    {% set streaming_rate_limit = config.get('streaming_rate_limit') | int %}
+    {% if streaming_rate_limit %}
+        with (streaming_rate_limit = {{ streaming_rate_limit }})
+    {% endif %}
     {% set contract_config = config.get('contract') %}
     {% if contract_config.enforced %}
       {{ get_assert_columns_equivalent(sql) }}


### PR DESCRIPTION
This PR allows for the specification of a `streaming_rate_limit` for MV creation. See [here](https://docs.risingwave.com/docs/current/troubleshoot-oom/#oom-when-creating-materialized-views) for its use.

Script can now appear as such:
```sql
{{ config(
    materialized="materialized_view",
    streaming_rate_limit=2500
) }}
SELECT *
FROM test_table
```

and output DDL will look like:
```sql
CREATE MATERIALIZED VIEW mv_name
WITH (streaming_rate_limit=2500)
AS
SELECT *
FROM test_table
```

