### PR TITLE
feat: add create_indexes on table_with_connector and handle on_configuration_change

### DIFF
--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -199,3 +199,31 @@
         rows_affected="-1"
     ) %}
 {% endmacro %}
+
+{% macro risingwave__handle_on_configuration_change(old_relation, target_relation) %}
+    {#
+    This macro is used to handle the `on_configuration_change` configuration option.
+    It works both for `table_with_connector`, `table` and `materialized_view` materializations.
+    #}
+
+    {% set on_configuration_change = config.get('on_configuration_change', "continue") %}
+    {% set configuration_changes = get_materialized_view_configuration_changes(old_relation, config) %}
+
+    {% if configuration_changes is none %}
+      -- do nothing
+      {{ risingwave__execute_no_op(target_relation) }}
+    {% elif on_configuration_change == 'apply' %}
+      {% call statement('main') -%}
+        {{ risingwave__update_indexes_on_materialized_view(target_relation, configuration_changes.indexes) }}
+      {%- endcall %}
+    {% elif on_configuration_change == 'continue' %}
+        -- do nothing but a warning
+        {{ exceptions.warn("Configuration changes were identified and `on_configuration_change` was set to `continue` for {}".format(target_relation)) }}
+        {{ risingwave__execute_no_op(target_relation) }}
+    {% elif on_configuration_change == 'fail' %}
+        {{ exceptions.raise_fail_fast_error("Configuration changes were identified and `on_configuration_change` was set to `fail` for {}".format(target_relation)) }}
+    {% else %}
+        -- this only happens if the user provides a value other than `apply`, 'continue', 'fail'
+        {{ exceptions.raise_compiler_error("Unexpected configuration scenario") }}
+    {% endif %}
+{% endmacro %}

--- a/dbt/include/risingwave/macros/materializations/materialized_view.sql
+++ b/dbt/include/risingwave/macros/materializations/materialized_view.sql
@@ -23,28 +23,7 @@
 
     {{ create_indexes(target_relation) }}
   {% else %}
-    -- get config options
-    {% set on_configuration_change = config.get('on_configuration_change', "continue") %}
-    {% set configuration_changes = get_materialized_view_configuration_changes(old_relation, config) %}
-
-    {% if configuration_changes is none %}
-      -- do nothing
-      {{ materialized_view_execute_no_op(target_relation) }}
-    {% elif on_configuration_change == 'apply' %}
-      {% call statement('main') -%}
-        {{ risingwave__update_indexes_on_materialized_view(target_relation, configuration_changes.indexes) }}
-      {%- endcall %}
-    {% elif on_configuration_change == 'continue' %}
-        -- do nothing but a warn
-        {{ exceptions.warn("Configuration changes were identified and `on_configuration_change` was set to `continue` for `" ~ target_relation ~ "`") }}
-        {{ materialized_view_execute_no_op(target_relation) }}
-    {% elif on_configuration_change == 'fail' %}
-        {{ exceptions.raise_fail_fast_error("Configuration changes were identified and `on_configuration_change` was set to `fail` for `" ~ target_relation ~ "`") }}
-    {% else %}
-        -- this only happens if the user provides a value other than `apply`, 'continue', 'fail'
-        {{ exceptions.raise_compiler_error("Unexpected configuration scenario") }}
-
-    {% endif %}
+      {{ risingwave__handle_on_configuration_change(old_relation, target_relation) }}
   {% endif %}
 
   {% do persist_docs(target_relation, model) %}

--- a/dbt/include/risingwave/macros/materializations/materializedview.sql
+++ b/dbt/include/risingwave/macros/materializations/materializedview.sql
@@ -23,28 +23,7 @@
 
     {{ create_indexes(target_relation) }}
   {% else %}
-    -- get config options
-    {% set on_configuration_change = config.get('on_configuration_change', "continue") %}
-    {% set configuration_changes = get_materialized_view_configuration_changes(old_relation, config) %}
-
-    {% if configuration_changes is none %}
-      -- do nothing
-      {{ materialized_view_execute_no_op(target_relation) }}
-    {% elif on_configuration_change == 'apply' %}
-      {% call statement('main') -%}
-        {{ risingwave__update_indexes_on_materialized_view(target_relation, configuration_changes.indexes) }}
-      {%- endcall %}
-    {% elif on_configuration_change == 'continue' %}
-        -- do nothing but a warn
-        {{ exceptions.warn("Configuration changes were identified and `on_configuration_change` was set to `continue` for `" ~ target_relation ~ "`") }}
-        {{ materialized_view_execute_no_op(target_relation) }}
-    {% elif on_configuration_change == 'fail' %}
-        {{ exceptions.raise_fail_fast_error("Configuration changes were identified and `on_configuration_change` was set to `fail` for `" ~ target_relation ~ "`") }}
-    {% else %}
-        -- this only happens if the user provides a value other than `apply`, 'continue', 'fail'
-        {{ exceptions.raise_compiler_error("Unexpected configuration scenario") }}
-
-    {% endif %}
+      {{ risingwave__handle_on_configuration_change(old_relation, target_relation) }}
   {% endif %}
 
   {% do persist_docs(target_relation, model) %}

--- a/dbt/include/risingwave/macros/materializations/table_with_connector.sql
+++ b/dbt/include/risingwave/macros/materializations/table_with_connector.sql
@@ -23,7 +23,7 @@
 
     {{ create_indexes(target_relation) }}
   {% else %}
-    {{ risingwave__execute_no_op(target_relation) }}
+    {{ risingwave__handle_on_configuration_change(old_relation, target_relation) }}
   {% endif %}
 
   {% do persist_docs(target_relation, model) %}

--- a/dbt/include/risingwave/macros/materializations/table_with_connector.sql
+++ b/dbt/include/risingwave/macros/materializations/table_with_connector.sql
@@ -20,6 +20,8 @@
     {% call statement('main') -%}
       {{ risingwave__run_sql(sql) }}
     {%- endcall %}
+
+    {{ create_indexes(target_relation) }}
   {% else %}
     {{ risingwave__execute_no_op(target_relation) }}
   {% endif %}


### PR DESCRIPTION
**EDIT**
Ok, as I mixed around with this a bit more I realized that if you do `table_with_connector` you occasionally might want to update the indexes on the table without having to re-create the entire table by running `--full-refresh`. 
Ergo, I refactored the `on_configuration_change` for the MWs to also be applied for the `table_with_connector`. 
A similar issue was raised to dbt-core recently: https://github.com/dbt-labs/dbt-core/issues/9510 

This works as expected:

- `apply` -> drop the indexes and re-create them, without truncating the table
- `continue` -> a warning is raised but skipped 
- `fail` -> compile error

I have verified this on our test cluster but worth to perhaps start to add tests . Let me know what you think @chenzl25.

---
Smol fix, adding index creation on `table_with_connector` for `SINK INTO` kind of relations.