### PR TITLE
feat: add `sql_header` support

### DIFF
--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -75,6 +75,9 @@
 {% endmacro %}
 
 {% macro risingwave__create_view_as(relation, sql) -%}
+    {%- set sql_header = config.get("sql_header", none) -%}
+    {{ sql_header if sql_header is not none }}
+
   create view if not exists {{ relation }}
     {% set contract_config = config.get('contract') %}
     {% if contract_config.enforced %}
@@ -85,6 +88,9 @@
 {%- endmacro %}
 
 {% macro risingwave__create_table_as(relation, sql) -%}
+    {%- set sql_header = config.get("sql_header", none) -%}
+    {{ sql_header if sql_header is not none }}
+
   create table if not exists {{ relation }}
     {% set contract_config = config.get('contract') %}
     {% if contract_config.enforced %}
@@ -95,6 +101,9 @@
 {%- endmacro %}
 
 {% macro risingwave__create_materialized_view_as(relation, sql) -%}
+    {%- set sql_header = config.get("sql_header", none) -%}
+    {{ sql_header if sql_header is not none }}
+
   create materialized view if not exists {{ relation }}
     {% set contract_config = config.get('contract') %}
     {% if contract_config.enforced %}
@@ -105,6 +114,9 @@
 {%- endmacro %}
 
 {% macro risingwave__create_sink(relation, sql) -%}
+    {%- set sql_header = config.get("sql_header", none) -%}
+    {{ sql_header if sql_header is not none }}
+
     {%- set _format_parameters = config.get("format_parameters") -%}
     {%- set data_format = config.get("data_format") -%}
     {%- set data_encode = config.get("data_encode") -%}


### PR DESCRIPTION
Support usage of e.g. https://docs.getdbt.com/reference/resource-configs/sql_header. Useful for declaring UDFs that are tightly connected to the MW, for example:

```sql
{{ config(materialized="materialized_view") }}

{# 
This will re-create the UDF when this model is run specifically.
This is quite convenient due to the fact that if you drop an UDF and 
it is currently used in a MW -> then the MW will use the old version of the UDF.
Having it like this, coupled to the model, we can at least ensure that it gets updated
whenever the model also updates. 
#}
{% call set_sql_header(config) %}
DROP FUNCTION IF EXISTS gcd(a int, b int));

CREATE FUNCTION gcd(a int, b int) RETURNS int LANGUAGE javascript AS $$
    if(a == null || b == null) {
        return null;
    }
    while (b != 0) {
        let t = b;
        b = a % b;
        a = t;
    }
    return a;
$$;
{% endcall %}

select *, gcd(column_a, column_b) as gcd
from {{ ref("upstream_model") }}
```


