### PR TITLE
Zero down-time in-place MV modifications

### DIFF
--- a/dbt/include/risingwave/macros/materializations/materialized_view.sql
+++ b/dbt/include/risingwave/macros/materializations/materialized_view.sql
@@ -9,21 +9,124 @@
                                                 database=database,
                                                 type='materialized_view') -%}
 
-  {% if full_refresh_mode and old_relation %}
-    {{ adapter.drop_relation(old_relation) }}
+  {# If any table is backfilling, we short-circuit and wait until the database is in a stable-state #}
+  {%- set is_any_job_running = run_query("SHOW JOBS;") | length > 0 -%}
+  {% if is_any_job_running %}
+    {{ exceptions.raise_compiler_error('There are jobs running, short-circuiting. Please wait until jobs are completed') }}
+  {% endif %}
+
+  {%- set hash = local_md5(sql) -%}
+  {%- set has_current_mv_hash_changed_query = "SELECT coalesce((
+        SELECT hash FROM relation_hashes WHERE target_relation = '" ~ target_relation ~ "'
+      ) != '" ~ hash ~ "', true);" %}
+  {%- set are_parent_mvs_droppable_query = "SELECT coalesce((
+        SELECT definition FROM rw_materialized_views
+        JOIN rw_schemas ON rw_schemas.id = rw_materialized_views.schema_id
+        WHERE rw_schemas.name = '" ~ schema ~ "' AND rw_materialized_views.name = '" ~ identifier ~ "'
+      ), '') ilike '%internal_droppable__%';" -%}
+  {%- set has_current_mv_hash_changed = run_query(has_current_mv_hash_changed_query).columns[0][0] -%}
+  {%- set are_parent_mvs_droppable = run_query(are_parent_mvs_droppable_query).columns[0][0] -%}
+  {{ log("has_current_mv_hash_changed: " ~ has_current_mv_hash_changed) }}
+  {{ log("are_parent_mvs_droppable: " ~ are_parent_mvs_droppable) }}
+
+  {# Full-refresh avoids reusing existing relations and drops any table.
+     We have to cascade in case the relation has dependencies. #}
+  {% if (full_refresh_mode and old_relation) or (old_relation and old_relation.type != 'materialized_view') %}
+    {{ log("Dropping relation {} to force full refresh/change type".format(old_relation)) }}
+    {{ risingwave__drop_relation(old_relation) }}
+    {%- set old_relation = none -%}
   {% endif %}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-  {% if old_relation is none or (full_refresh_mode and old_relation) %}
+  {{ log("Creating materialized view {}".format(config.get('deprecated'))) }}
+  {% if config.get('deprecated') %}
+    {% if old_relation is not none %}
+      {# If the relation is deprecated, we can just drop it #}
+      {{ log("Dropping relation {} as it is deprecated".format(old_relation)) }}
+      {{ risingwave__drop_relation(old_relation) }}
+    {% endif %}
     {% call statement('main') -%}
+    select 1;
+    {%- endcall %}
+  {% elif old_relation is none %}
+    {# If there is no previous relation, we can just create the current MV directly #}
+    {{ log ("Creating relation {} as {}".format(target_relation, sql)) }}
+    {% call statement('main') -%}
+      INSERT INTO relation_hashes (target_relation, hash)
+      VALUES ('{{ target_relation }}', '{{ hash }}')
+      ;
       {{ risingwave__create_materialized_view_as(target_relation, sql) }}
+      FLUSH;
     {%- endcall %}
 
+    {# TODO(vlad): Reaching this statement takes a long while... #}
     {{ create_indexes(target_relation) }}
+  {%- elif has_current_mv_hash_changed or are_parent_mvs_droppable -%}
+    {# We have to switch-over to the new version without causing downtime #}
+    {{ log("Found change in relations...") }}
+    {%- set temp_relation = api.Relation.create(identifier="internal_tmp__" ~ target_relation.identifier,
+                                                schema=target_relation.schema,
+                                                database=target_relation.database,
+                                                type='materialized_view') -%}
+    {%- set temp_relation_exists = adapter.get_relation(schema=temp_relation.schema,
+                                                        identifier=temp_relation.identifier,
+                                                        database=temp_relation.database) -%}
+    {%- set has_temp_relation_hash_changed_query = "SELECT coalesce((
+        SELECT hash FROM relation_hashes WHERE target_relation = '" ~ temp_relation ~ "'
+    ) != '" ~ hash ~ "', true);" -%}
+    {%- set are_temp_parent_mvs_droppable_query = "SELECT coalesce((
+        SELECT definition FROM rw_materialized_views
+        JOIN rw_schemas ON rw_schemas.id = rw_materialized_views.schema_id
+        WHERE rw_schemas.name = '" ~ schema ~ "' AND rw_materialized_views.name = '" ~ temp_relation.identifier ~ "'
+      ), '') ilike '%internal_droppable__%';" -%}
+    {%- set has_temp_relation_hash_changed = run_query(has_temp_relation_hash_changed_query).columns[0][0] -%}
+    {%- set are_temp_parent_mvs_droppable = run_query(are_temp_parent_mvs_droppable_query).columns[0][0] -%}
+    {{ log("has_temp_relation_hash_changed: " ~ has_temp_relation_hash_changed) }}
+    {{ log("are_temp_parent_mvs_droppable: " ~ are_temp_parent_mvs_droppable) }}
+
+    {# If the current tmp table isn't for the current MV, we have to drop it and start over #}
+    {%- if temp_relation_exists and (has_temp_relation_hash_changed or are_temp_parent_mvs_droppable) -%}
+      {{ log("Dropping temp relation {} as it's not current".format(temp_relation)) }}
+      {{ risingwave__drop_relation(temp_relation) }}
+      {%- set temp_relation_exists = false -%}
+    {%- endif -%}
+
+    {%- if not temp_relation_exists -%}
+      {{ log("Creating temp relation {} as {}".format(temp_relation, sql)) }}
+      {% call statement('main') -%}
+        INSERT INTO relation_hashes (target_relation, hash)
+        VALUES ('{{ temp_relation }}', '{{ hash }}')
+        ;
+        {{ risingwave__create_materialized_view_as(temp_relation, sql) }}
+        FLUSH;
+      {%- endcall %}
+
+      {# TODO(vlad): Ideally sleep for 20 minutes rather than failing... #}
+      {{ exceptions.raise_compiler_error('Materialized view being created... Please wait until it is done backfilling') }}
+    {%- endif -%}
+
+    {# The tmp exists and is initialized, we just need to swap it #}
+    {%- set droppable_old_relation = api.Relation.create(identifier="internal_droppable__" ~ target_relation.identifier,
+                                                schema=target_relation.schema,
+                                                database=target_relation.database,
+                                                type='materialized_view') -%}
+    {{ log("Swapping relation {} with {}".format(old_relation, target_relation)) }}
+
+    {# TODO(vlad): You can't just create indexes like that... #}
+    {% call statement('main') -%}
+      {{ create_indexes(temp_relation) }}
+      ALTER MATERIALIZED VIEW {{ temp_relation }} SWAP WITH {{ target_relation }};
+      INSERT INTO relation_hashes (target_relation, hash) VALUES ('{{ target_relation }}', '{{ hash }}');
+      DELETE FROM relation_hashes WHERE target_relation = '{{ temp_relation }}';
+      FLUSH;
+      ALTER MATERIALIZED VIEW {{ temp_relation }} RENAME TO {{ droppable_old_relation.identifier }};
+      FLUSH;
+    {%- endcall %}
   {% else %}
-      {{ risingwave__handle_on_configuration_change(old_relation, target_relation) }}
+    {{ log("No change in relations") }}
+    {{ risingwave__handle_on_configuration_change(old_relation, target_relation) }}
   {% endif %}
 
   {% do persist_docs(target_relation, model) %}


### PR DESCRIPTION
Being able to make in-place MV modifications is super great for DevX. We can leverage a lot of what DBT provides to get zero-downtime modifications.

Limitations:
- `relation_hashes` must already exist and be created by the user
- The user needs to run `dbt build` multiple times to get all downstream MVs updated. With the #54 funciton, this will not be necessary.
- Tables with `internal_droppable__` are never dropped. It's up to the user to add a `on-run-end` configuration to drop all tables prefixed with `internal_droppable__`.
- I don't believe indexes are created always?

Tests that should be supported:
- Chained materialized views, just normal create
- Changes on sources are reflected correctly?
- Dropping a materialized view
- Full refresh correctly cascades everything
- Index creation happens correctly on full refresh. Especially for MVs that take a while to bootstrap.
- In-place MV modifications:
    - Changing an MV with no downstream dependencies. Correct ratcheting
    - Changing an MV with a downstream dependency. Correct ratcheting.
    - Changing an MV. Ratcheting, then changing the definition again -- temp table should be dropped
    - Changing an MV. Ratcheting, then modifying tha parent and ensuring we drop the temp table
    - Index creation happens correctly
    - Index create doesn't block the alter materialized view things
Validator:
- At each step, each MV should be newer than its parents.
- Also, if you diff target/ hashes with relation_hashes, they should be the same.
- No internal_tmp__ tables should exist
- No internal_droppable__ tables should exist
- No unused tables should exist.
