### PR TITLE
chore: bump dependencies to 1.9

### DIFF
--- a/dbt/adapters/risingwave/__version__.py
+++ b/dbt/adapters/risingwave/__version__.py
@@ -1,1 +1,1 @@
-version = "1.8.1"
+version = "1.9.0"

--- a/setup.py
+++ b/setup.py
@@ -32,12 +32,12 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-postgres~=1.8.0",
-        "dbt-core~=1.8.0",
+        "dbt-postgres~=1.9.0",
+        "dbt-core~=1.9.0",
         # not sure if these are needed due to inheritance from dbt-postgres
         # but doesn't hurt to be explicit I suppose
         "dbt-common>=1.0.4,<2.0",
-        "dbt-adapters>=1.1.1,<2.0",
+        "dbt-adapters>=1.7.0,<2.0",
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -45,10 +45,11 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
Bump to v1.9 to support new features from dbt-core. Significant update, breaking change of removing support for python3.8, see https://github.com/dbt-labs/dbt-postgres/pull/161 

We can also consider to move away from using `setup.py` to start using `uv` and `hatch` as build system if you want @chenzl25 ?