### PR TITLE
fix: fix drop primary index of table

### DIFF
--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -201,6 +201,7 @@
     where t.relname = '{{ relation.identifier }}'
       and n.nspname = '{{ relation.schema }}'
       and t.relkind in ('r', 'm')
+      and ix.indisprimary = false
     )
     select name, method, "unique", array_to_string(array_agg(attname order by ord), ',') as column_names from index_info
     group by 1, 2, 3


### PR DESCRIPTION
- Currently `risingwave__get_show_indexes_sql` will select the primary index which is unexpected and confusing, because we can't drop a primary index.