### PR TITLE
fix: overwrite truncate 

### DIFF
--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -243,3 +243,9 @@
         {{ exceptions.raise_compiler_error("Unexpected configuration scenario") }}
     {% endif %}
 {% endmacro %}
+
+{% macro risingwave__truncate_relation(relation) -%}
+  {% call statement('truncate_relation') -%}
+    delete from {{ relation }}
+  {%- endcall %}
+{% endmacro %}


### PR DESCRIPTION
Since risingwave doesn't support truncate statement, we use delete statement instead.