### PR TITLE
fix: fix duplicate relation name

### DIFF
--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -7,14 +7,15 @@
     '{{ schema_relation.database }}' as database,
     rw_relations.name as name,
     rw_schemas.name as schema,
-    CASE WHEN relation_type = 'materialized view' THEN
+    FIRST_VALUE(CASE WHEN relation_type = 'materialized view' THEN
       'materialized_view'
       else relation_type
-    END AS type
+    END order by relation_type desc) AS type
     from rw_relations join rw_schemas on schema_id=rw_schemas.id
     where rw_schemas.name not in ('rw_catalog', 'information_schema', 'pg_catalog')
     and relation_type in ('table', 'view', 'source', 'sink', 'materialized view', 'index')
     AND rw_schemas.name = '{{ schema_relation.schema }}'
+    group by database, name, schema
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}


### PR DESCRIPTION
- RisingWave table with connector would create a table and a source with the same name, however, it is not acceptable to dbt-core, so we will dedup relation name and show the type as table if duplicated relations exist.