### PR TITLE
fix: Refine Claude Code Review workflow trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"


### PR DESCRIPTION
## Summary
- Remove `synchronize` trigger from Claude Code Review workflow
- Now only triggers when PR is opened, not on subsequent pushes
- Reduces excessive automated reviews while maintaining initial PR review coverage

## Test plan
- [ ] Verify workflow only runs when new PR is opened
- [ ] Confirm no runs occur on push to existing PR branches

🤖 Generated with [Claude Code](https://claude.ai/code)