### PR TITLE
fix: only compare index key columns

### DIFF
--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -191,7 +191,7 @@
         'btree'                                     as method,
         ix.indisunique                              as "unique",
         a.attname                                   as attname,
-        array_position(ix.indkey, a.attnum)        as ord
+        array_position(ix.indkey, a.attnum)         as ord
     from pg_index ix
     join pg_class i
         on i.oid = ix.indexrelid
@@ -202,6 +202,9 @@
     join pg_attribute a
         on a.attrelid = t.oid
         and a.attnum = ANY(ix.indkey)
+        -- Only include the first indnkeyatts columns (the actual index key columns)
+        -- The rest are implicit INCLUDE columns in RisingWave
+        and array_position(ix.indkey, a.attnum) <= ix.indnkeyatts
     where t.relname = '{{ relation.identifier }}'
       and n.nspname = '{{ relation.schema }}'
       and t.relkind in ('r', 'm')


### PR DESCRIPTION
Behavior before change compared the explicitly declared columns in the model config with ALL columns INCLUDED for that index. By default RW included ALL columns of that table as described [here](https://docs.risingwave.com/processing/indexes#how-to-decide-which-columns-to-include%3F). We have that indexes declared in the config are always <= included by default. So to dbt it looked like indexes actually changed, where in fact the index comparison was faulty. This caused unnecessary dropped and recreated indexes.