### PR TITLE
feat: add enable_serverless_backfill session variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ The adapter supports RisingWave session settings such as `streaming_parallelism`
 
 See [docs/configuration.md](docs/configuration.md) for the full configuration matrix.
 
+### Serverless Backfill
+
+Use `enable_serverless_backfill=true` in a model config or profile to enable serverless backfills for streaming queries.
+
+See [docs/configuration.md](docs/configuration.md) for examples.
+
 ### Background DDL
 
 `background_ddl=true` lets supported materializations submit background DDL while still preserving dbt semantics by issuing RisingWave `WAIT` before dbt continues.

--- a/dbt/adapters/risingwave/connections.py
+++ b/dbt/adapters/risingwave/connections.py
@@ -23,6 +23,7 @@ class RisingWaveCredentials(PostgresCredentials):
     streaming_parallelism: Optional[int] = None
     streaming_parallelism_for_backfill: Optional[int] = None
     streaming_max_parallelism: Optional[int] = None
+    enable_serverless_backfill: Optional[bool] = None
 
     @property
     def type(self):
@@ -154,6 +155,7 @@ class RisingWaveConnectionManager(PostgresConnectionManager):
                     credentials.streaming_parallelism_for_backfill,
                 ),
                 ("streaming_max_parallelism", credentials.streaming_max_parallelism),
+                ("enable_serverless_backfill", credentials.enable_serverless_backfill),
             )
             for setting, value in session_settings:
                 if value is not None:

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -29,6 +29,11 @@
     {%- do header_parts.append("set streaming_max_parallelism = " ~ streaming_max_parallelism ~ ";") -%}
   {%- endif -%}
 
+  {%- set enable_serverless_backfill = config.get("enable_serverless_backfill", none) -%}
+  {%- if enable_serverless_backfill is not none -%}
+    {%- do header_parts.append("set enable_serverless_backfill = " ~ enable_serverless_backfill | lower ~ ";") -%}
+  {%- endif -%}
+
   {{- header_parts | join("\n") -}}
 {%- endmacro %}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,7 @@ default:
       streaming_parallelism: 2
       streaming_parallelism_for_backfill: 2
       streaming_max_parallelism: 8
+      enable_serverless_backfill: true
   target: dev
 ```
 
@@ -46,6 +47,7 @@ Supported adapter-specific profile keys:
 | `streaming_parallelism` | Sets `SET streaming_parallelism = ...` for the session. |
 | `streaming_parallelism_for_backfill` | Sets `SET streaming_parallelism_for_backfill = ...` for the session. |
 | `streaming_max_parallelism` | Sets `SET streaming_max_parallelism = ...` for the session. |
+| `enable_serverless_backfill` | Sets `SET enable_serverless_backfill = true/false` for the session. |
 
 ## Model Configuration
 
@@ -109,6 +111,30 @@ from {{ ref('events') }}
 ```
 
 These values are emitted in the SQL header before the model DDL runs.
+
+### Serverless Backfill
+
+Use `enable_serverless_backfill` to enable serverless backfills for streaming queries on a per-model basis:
+
+```sql
+{{ config(
+    materialized='materialized_view',
+    enable_serverless_backfill=true
+) }}
+
+select *
+from {{ ref('events') }}
+```
+
+Or set it globally in `dbt_project.yml`:
+
+```yaml
+models:
+  my_project:
+    +enable_serverless_backfill: true
+```
+
+This emits `set enable_serverless_backfill = true;` before the model DDL runs.
 
 ### Background DDL
 


### PR DESCRIPTION
Support the boolean RisingWave session variable
`enable_serverless_backfill` at both the profile level (applied once when the connection opens) and the model level (emitted as a SET statement in the SQL header before each model's DDL).

Closes https://github.com/risingwavelabs/dbt-risingwave/issues/93