### PR TITLE
feat: support first version of dbt functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,28 @@ See [docs/configuration.md](docs/configuration.md) for supported materialization
 
 See [docs/zero-downtime-rebuilds.md](docs/zero-downtime-rebuilds.md) for requirements, cleanup behavior, and helper commands.
 
+### Functions
+
+`dbt-risingwave` now supports a first version of dbt `function` resources for RisingWave SQL scalar UDFs.
+
+Current contract:
+
+- supported: SQL scalar functions
+- materialization: `CREATE FUNCTION IF NOT EXISTS`
+- supported volatility config:
+  - `deterministic` -> `IMMUTABLE`
+  - `stable` -> `STABLE`
+  - `non-deterministic` -> `VOLATILE`
+
+Current limits:
+
+- no replace/update path for an existing function body
+- no overload-family management
+- no aggregate/table/remote/embedded python/javascript functions
+- no default arguments
+
+See [docs/functions.md](docs/functions.md) for the full first-version contract and example layout.
+
 ### Indexes
 
 RisingWave indexes support `INCLUDE` and `DISTRIBUTED BY` clauses beyond what the Postgres adapter exposes. Configure them in the model config:
@@ -134,6 +156,7 @@ See [docs/configuration.md](docs/configuration.md) for adapter-specific configur
 
 - [docs/README.md](docs/README.md): documentation index
 - [docs/configuration.md](docs/configuration.md): profile options, model configs, sink settings, and background DDL usage
+- [docs/functions.md](docs/functions.md): first-version SQL scalar function support and limitations
 - [docs/zero-downtime-rebuilds.md](docs/zero-downtime-rebuilds.md): zero-downtime rebuild behavior for materialized views and views
 
 ## dbt Run Behavior

--- a/dbt/adapters/risingwave/relation.py
+++ b/dbt/adapters/risingwave/relation.py
@@ -24,6 +24,7 @@ class RisingWaveRelationType(StrEnum):
     MaterializedView = "materialized_view"
     MaterializedView_v1_5_0 = "materializedview"
     External = "external"
+    Function = "function"
 
     Source = "source"
     Sink = "sink"

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -39,19 +39,39 @@
 
 {% macro risingwave__list_relations_without_caching(schema_relation) %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
-    select
-    '{{ schema_relation.database }}' as database,
-    rw_relations.name as name,
-    rw_schemas.name as schema,
-    FIRST_VALUE(CASE WHEN relation_type = 'materialized view' THEN
-      'materialized_view'
-      else relation_type
-    END order by relation_type desc) AS type
-    from rw_relations join rw_schemas on schema_id=rw_schemas.id
-    where rw_schemas.name not in ('rw_catalog', 'information_schema', 'pg_catalog')
-    and relation_type in ('table', 'view', 'source', 'sink', 'materialized view', 'index')
-    AND rw_schemas.name = '{{ schema_relation.schema }}'
-    group by database, name, schema
+    with rw_schema_relations as (
+      select
+        '{{ schema_relation.database }}' as database,
+        rw_relations.name as name,
+        rw_schemas.name as schema,
+        case
+          when relation_type = 'materialized view' then 'materialized_view'
+          else relation_type
+        end as type
+      from rw_relations
+      join rw_schemas on schema_id = rw_schemas.id
+      where rw_schemas.name not in ('rw_catalog', 'information_schema', 'pg_catalog')
+        and relation_type in ('table', 'view', 'source', 'sink', 'materialized view', 'index')
+        and rw_schemas.name = '{{ schema_relation.schema }}'
+    ),
+    rw_schema_functions as (
+      select
+        '{{ schema_relation.database }}' as database,
+        rw_functions.name as name,
+        rw_schemas.name as schema,
+        'function' as type
+      from rw_functions
+      join rw_schemas on rw_functions.schema_id = rw_schemas.id
+      where rw_schemas.name not in ('rw_catalog', 'information_schema', 'pg_catalog')
+        and rw_schemas.name = '{{ schema_relation.schema }}'
+      group by database, name, schema
+      having count(*) = 1
+    )
+    select database, name, schema, type
+    from rw_schema_relations
+    union all
+    select database, name, schema, type
+    from rw_schema_functions
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}
@@ -157,6 +177,8 @@
       drop source if exists {{ relation }} cascade
     {% elif relation.type == 'sink' %}
       drop sink if exists {{ relation }} cascade
+    {% elif relation.type == 'function' %}
+      drop function if exists {{ relation }}
     {% endif %}
   {%- endcall %}
 {% endmacro %}

--- a/dbt/include/risingwave/macros/materializations/functions/scalar.sql
+++ b/dbt/include/risingwave/macros/materializations/functions/scalar.sql
@@ -1,0 +1,10 @@
+{% macro risingwave__scalar_function_sql(target_relation) %}
+    CREATE FUNCTION IF NOT EXISTS {{ target_relation.render() }} ({{ formatted_scalar_function_args_sql() }})
+    RETURNS {{ model.returns.data_type }}
+    {{ scalar_function_volatility_sql() }}
+    LANGUAGE SQL
+    AS
+    $$
+       {{ model.compiled_code }}
+    $$;
+{% endmacro %}

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This directory contains the adapter-specific documentation that used to be mixed
 ## Guides
 
 - [configuration.md](configuration.md): profile settings, model configuration, and sink options
+- [functions.md](functions.md): first-version SQL scalar function support and its limits
 - [zero-downtime-rebuilds.md](zero-downtime-rebuilds.md): zero-downtime rebuild flow for materialized views and views
 
 ## Start Here
@@ -13,4 +14,5 @@ If you are new to the adapter:
 
 1. Read the root [README.md](../README.md) for installation and basic project setup.
 2. Read [configuration.md](configuration.md) for RisingWave-specific configuration.
-3. Read [zero-downtime-rebuilds.md](zero-downtime-rebuilds.md) if you plan to use swap-based rebuilds.
+3. Read [functions.md](functions.md) if you plan to manage SQL scalar UDFs with dbt.
+4. Read [zero-downtime-rebuilds.md](zero-downtime-rebuilds.md) if you plan to use swap-based rebuilds.

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1,0 +1,92 @@
+# Functions
+
+`dbt-risingwave` supports the upstream dbt `function` resource for a constrained first version of RisingWave UDF support.
+
+## Scope
+
+This first version supports:
+
+- SQL scalar functions
+- function creation from dbt `functions/` resources
+- function references from models through `{{ function('name') }}(...)`
+- function volatility config:
+  - `deterministic` -> `IMMUTABLE`
+  - `stable` -> `STABLE`
+  - `non-deterministic` -> `VOLATILE`
+
+## Example
+
+Project layout:
+
+```text
+functions/
+  price_for_xlarge.sql
+  price_for_xlarge.yml
+models/
+  udf_example.sql
+```
+
+Function SQL:
+
+```sql
+select price * 2
+```
+
+Function YAML:
+
+```yaml
+functions:
+  - name: price_for_xlarge
+    description: Double the price
+    arguments:
+      - name: price
+        data_type: float
+    returns:
+      data_type: float
+```
+
+Model usage:
+
+```sql
+{{ config(materialized='view') }}
+
+select {{ function('price_for_xlarge') }}(100::float8) as xlarge_price
+```
+
+## First-Version Contract
+
+This adapter currently materializes SQL scalar functions with:
+
+```sql
+CREATE FUNCTION IF NOT EXISTS ...
+```
+
+That contract has two important consequences:
+
+1. dbt can create and reference the function.
+2. dbt does not replace or update an existing RisingWave function body.
+
+If the function definition changes, drop the function first or deploy it under a new name.
+
+## Current Limitations
+
+This first version does not support:
+
+- `CREATE OR REPLACE FUNCTION`
+- updating an existing function body through dbt
+- overload-family management
+- aggregate functions
+- table functions
+- remote or external UDFs
+- embedded `python` / `javascript` UDFs
+- default arguments
+
+The overload limitation is especially important. The adapter only treats a function name as a manageable dbt relation when that name maps to a single signature inside the schema.
+
+## Validation Example
+
+The live example and singular tests for this first version live in the companion project:
+
+- `dbt_rw_nexmark`
+
+See its function example for a runnable RisingWave validation flow.


### PR DESCRIPTION
## Summary
- support first-version dbt function relations in the RisingWave adapter
- add SQL scalar function materialization and function relation drop/list handling
- document the first-version contract and limitations

## Contract
- supports SQL scalar functions only
- materializes with `CREATE FUNCTION IF NOT EXISTS`
- does not replace or update an existing function body
- does not manage overload families
- does not support aggregate, table, remote, embedded python/javascript functions, or default args

## Validation
- validated live through the companion `dbt_rw_nexmark` example PR
- command run there: `dbt build --select +udf_price_example`