### PR TITLE
feat: support javascript scalar functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,13 @@ See [docs/zero-downtime-rebuilds.md](docs/zero-downtime-rebuilds.md) for require
 
 ### Functions
 
-`dbt-risingwave` now supports a first version of dbt `function` resources for RisingWave SQL scalar UDFs.
+`dbt-risingwave` now supports a first version of dbt `function` resources for RisingWave scalar UDFs.
 
 Current contract:
 
-- supported: SQL scalar functions
+- supported:
+  - SQL scalar functions
+  - JavaScript scalar functions via `functions/*.sql` plus `config.language: javascript`
 - materialization: `CREATE FUNCTION IF NOT EXISTS`
 - supported volatility config:
   - `deterministic` -> `IMMUTABLE`
@@ -89,8 +91,10 @@ Current limits:
 
 - no replace/update path for an existing function body
 - no overload-family management
-- no aggregate/table/remote/embedded python/javascript functions
+- no aggregate/table/remote functions
+- no embedded python functions
 - no default arguments
+- upstream dbt-core still only parses function resources from `.sql` and `.py`, so JavaScript uses adapter config rather than native `.js` resources
 
 See [docs/functions.md](docs/functions.md) for the full first-version contract and example layout.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Current contract:
   - SQL scalar functions
   - JavaScript scalar functions via `functions/*.sql` plus `config.language: javascript`
 - materialization: `CREATE FUNCTION IF NOT EXISTS`
+- JavaScript async options:
+  - `config.async: true` -> `WITH (async = true)`
+  - `config.batch: true` -> `WITH (batch = true)`
+  - `config.always_retry_on_network_error: true` -> `WITH (always_retry_on_network_error = true)`
 - supported volatility config:
   - `deterministic` -> `IMMUTABLE`
   - `stable` -> `STABLE`

--- a/dbt/adapters/risingwave/relation.py
+++ b/dbt/adapters/risingwave/relation.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Optional, Type
 
 from dbt.adapters.postgres.relation import PostgresRelation
@@ -38,6 +38,18 @@ class RisingWaveRelation(PostgresRelation):
     @classproperty
     def get_relation_type(cls) -> Type[RisingWaveRelationType]:
         return RisingWaveRelationType
+
+    def get_function_config(self, model):
+        function_config = super().get_function_config(model)
+        if function_config is None:
+            return None
+
+        configured_language = model.get("config", {}).get("language")
+        if configured_language:
+            return replace(
+                function_config, language=str(configured_language).lower()
+            )
+        return function_config
 
     # RisingWave has no limitation on relation name length.
     # We set a relatively large value right now.

--- a/dbt/include/risingwave/macros/materializations/functions/scalar.sql
+++ b/dbt/include/risingwave/macros/materializations/functions/scalar.sql
@@ -10,6 +10,17 @@
 {% endmacro %}
 
 {% macro risingwave__scalar_function_javascript(target_relation) %}
+    {% set options = [] %}
+    {% if model.config.get('async') %}
+        {% do options.append('async = true') %}
+    {% endif %}
+    {% if model.config.get('batch') %}
+        {% do options.append('batch = true') %}
+    {% endif %}
+    {% if model.config.get('always_retry_on_network_error') %}
+        {% do options.append('always_retry_on_network_error = true') %}
+    {% endif %}
+
     CREATE FUNCTION IF NOT EXISTS {{ target_relation.render() }} ({{ formatted_scalar_function_args_sql() }})
     RETURNS {{ model.returns.data_type }}
     {{ scalar_function_volatility_sql() }}
@@ -17,5 +28,8 @@
     AS
     $$
        {{ model.compiled_code }}
-    $$;
+    $$
+    {%- if options | length > 0 %}
+    WITH ({{ options | join(', ') }})
+    {%- endif %};
 {% endmacro %}

--- a/dbt/include/risingwave/macros/materializations/functions/scalar.sql
+++ b/dbt/include/risingwave/macros/materializations/functions/scalar.sql
@@ -8,3 +8,14 @@
        {{ model.compiled_code }}
     $$;
 {% endmacro %}
+
+{% macro risingwave__scalar_function_javascript(target_relation) %}
+    CREATE FUNCTION IF NOT EXISTS {{ target_relation.render() }} ({{ formatted_scalar_function_args_sql() }})
+    RETURNS {{ model.returns.data_type }}
+    {{ scalar_function_volatility_sql() }}
+    LANGUAGE JAVASCRIPT
+    AS
+    $$
+       {{ model.compiled_code }}
+    $$;
+{% endmacro %}

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -7,6 +7,7 @@
 This first version supports:
 
 - SQL scalar functions
+- JavaScript scalar functions through `config.language: javascript`
 - function creation from dbt `functions/` resources
 - function references from models through `{{ function('name') }}(...)`
 - function volatility config:
@@ -15,6 +16,8 @@ This first version supports:
   - `non-deterministic` -> `VOLATILE`
 
 ## Example
+
+### SQL Scalar Function
 
 Project layout:
 
@@ -53,6 +56,48 @@ Model usage:
 select {{ function('price_for_xlarge') }}(100::float8) as xlarge_price
 ```
 
+### JavaScript Scalar Function
+
+Project layout:
+
+```text
+functions/
+  price_for_xlarge_js.sql
+  price_for_xlarge_js.yml
+models/
+  js_udf_example.sql
+```
+
+Function file:
+
+```sql
+export function price_for_xlarge_js(price) {
+    return price * 2;
+}
+```
+
+Function YAML:
+
+```yaml
+functions:
+  - name: price_for_xlarge_js
+    config:
+      language: javascript
+    arguments:
+      - name: price
+        data_type: float8
+    returns:
+      data_type: float8
+```
+
+Model usage:
+
+```sql
+{{ config(materialized='view') }}
+
+select {{ function('price_for_xlarge_js') }}(100::float8) as xlarge_price
+```
+
 ## First-Version Contract
 
 This adapter currently materializes SQL scalar functions with:
@@ -68,6 +113,16 @@ That contract has two important consequences:
 
 If the function definition changes, drop the function first or deploy it under a new name.
 
+For JavaScript, the function body is emitted as:
+
+```sql
+CREATE FUNCTION IF NOT EXISTS ... LANGUAGE JAVASCRIPT AS $$ ... $$;
+```
+
+The exported JavaScript function should match the dbt function name.
+
+This uses an adapter-level workaround for current dbt-core limits. Upstream dbt function parsing currently only accepts `.sql` and `.py` files, so JavaScript UDFs are authored in `functions/*.sql` and switched to JavaScript with `config.language: javascript`.
+
 ## Current Limitations
 
 This first version does not support:
@@ -78,8 +133,13 @@ This first version does not support:
 - aggregate functions
 - table functions
 - remote or external UDFs
-- embedded `python` / `javascript` UDFs
+- embedded `python` UDFs
 - default arguments
+- native `.js` function resources in dbt-core
+
+## Cluster Requirement
+
+JavaScript UDF creation depends on RisingWave having embedded JavaScript UDF support enabled. If the cluster disables `enable_embedded_javascript_udf`, dbt function creation will fail at execution time.
 
 The overload limitation is especially important. The adapter only treats a function name as a manageable dbt relation when that name maps to a single signature inside the schema.
 

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -8,6 +8,10 @@ This first version supports:
 
 - SQL scalar functions
 - JavaScript scalar functions through `config.language: javascript`
+- JavaScript async options through adapter config:
+  - `async`
+  - `batch`
+  - `always_retry_on_network_error`
 - function creation from dbt `functions/` resources
 - function references from models through `{{ function('name') }}(...)`
 - function volatility config:
@@ -122,6 +126,28 @@ CREATE FUNCTION IF NOT EXISTS ... LANGUAGE JAVASCRIPT AS $$ ... $$;
 The exported JavaScript function should match the dbt function name.
 
 This uses an adapter-level workaround for current dbt-core limits. Upstream dbt function parsing currently only accepts `.sql` and `.py` files, so JavaScript UDFs are authored in `functions/*.sql` and switched to JavaScript with `config.language: javascript`.
+
+### JavaScript Async Options
+
+For embedded JavaScript scalar UDFs, the adapter also maps these function configs into RisingWave `WITH (...)` options:
+
+```yaml
+functions:
+  - name: http_get_todo_name_js
+    config:
+      language: javascript
+      async: true
+      batch: false
+      always_retry_on_network_error: false
+```
+
+Current mapping:
+
+- `config.async: true` -> `WITH (async = true)`
+- `config.batch: true` -> `WITH (batch = true)`
+- `config.always_retry_on_network_error: true` -> `WITH (always_retry_on_network_error = true)`
+
+This is enough to support real async `fetch(...)` use cases such as HTTP GET and POST.
 
 ## Current Limitations
 


### PR DESCRIPTION
## Summary
- add adapter support for RisingWave JavaScript scalar dbt functions
- route `config.language: javascript` function resources to `LANGUAGE JAVASCRIPT`
- document the JavaScript contract and current dbt-core limitation

## Contract
- supported: JavaScript scalar functions
- current authoring path: `functions/*.sql` plus `config.language: javascript`
- not supported as native `.js` function resources because current dbt-core function parsing still only accepts `.sql` and `.py`
