### PR TITLE
feat: support external python scalar functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Current contract:
 - supported:
   - SQL scalar functions
   - JavaScript scalar functions via `functions/*.sql` plus `config.language: javascript`
+  - Python scalar functions via `functions/*.sql` plus `config.language: python`
+    - with `config.runtime_version: embedded`
 - materialization: `CREATE FUNCTION IF NOT EXISTS`
 - JavaScript async options:
   - `config.async: true` -> `WITH (async = true)`
@@ -96,9 +98,8 @@ Current limits:
 - no replace/update path for an existing function body
 - no overload-family management
 - no aggregate/table/remote functions
-- no embedded python functions
 - no default arguments
-- upstream dbt-core still only parses function resources from `.sql` and `.py`, so JavaScript uses adapter config rather than native `.js` resources
+- upstream dbt-core function contracts do not yet map cleanly to RisingWave-native `.js` / embedded `.py` authoring, so JavaScript and Python currently use adapter config on `functions/*.sql`
 
 See [docs/functions.md](docs/functions.md) for the full first-version contract and example layout.
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,10 @@ Current contract:
 - supported:
   - SQL scalar functions
   - JavaScript scalar functions via `functions/*.sql` plus `config.language: javascript`
-  - Python scalar functions via `functions/*.sql` plus `config.language: python`
-    - with `config.runtime_version: embedded`
+  - external Python scalar functions via `functions/*.sql` plus `config.language: python`
+    - with `config.link: http://host:port`
+    - optional `config.remote_name`
+    - optional `config.always_retry_on_network_error`
 - materialization: `CREATE FUNCTION IF NOT EXISTS`
 - JavaScript async options:
   - `config.async: true` -> `WITH (async = true)`
@@ -97,9 +99,9 @@ Current limits:
 
 - no replace/update path for an existing function body
 - no overload-family management
-- no aggregate/table/remote functions
+- no aggregate or table functions
 - no default arguments
-- upstream dbt-core function contracts do not yet map cleanly to RisingWave-native `.js` / embedded `.py` authoring, so JavaScript and Python currently use adapter config on `functions/*.sql`
+- upstream dbt-core function contracts do not yet map cleanly to RisingWave-native `.js` authoring or RisingWave external Python UDF authoring, so JavaScript and Python currently use adapter config on `functions/*.sql`
 
 See [docs/functions.md](docs/functions.md) for the full first-version contract and example layout.
 
@@ -165,7 +167,7 @@ See [docs/configuration.md](docs/configuration.md) for adapter-specific configur
 
 - [docs/README.md](docs/README.md): documentation index
 - [docs/configuration.md](docs/configuration.md): profile options, model configs, sink settings, and background DDL usage
-- [docs/functions.md](docs/functions.md): first-version SQL scalar function support and limitations
+- [docs/functions.md](docs/functions.md): first-version RisingWave scalar function support and limitations
 - [docs/zero-downtime-rebuilds.md](docs/zero-downtime-rebuilds.md): zero-downtime rebuild behavior for materialized views and views
 
 ## dbt Run Behavior

--- a/dbt/adapters/risingwave/relation.py
+++ b/dbt/adapters/risingwave/relation.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, replace
 from typing import Optional, Type
 
+from dbt.adapters.base.relation import FunctionConfig
 from dbt.adapters.postgres.relation import PostgresRelation
 from dbt.adapters.utils import classproperty
 from dbt.adapters.relation_configs.config_base import RelationResults
@@ -40,15 +41,29 @@ class RisingWaveRelation(PostgresRelation):
         return RisingWaveRelationType
 
     def get_function_config(self, model):
+        configured_language = model.get("config", {}).get("language")
+        if configured_language and str(configured_language).lower() == "python":
+            # dbt-core's native python function contract expects runtime_version and
+            # entry_point metadata, but RisingWave embedded Python UDFs do not use
+            # those fields. Provide adapter-local placeholders so we can still route
+            # the function to the python macro path.
+            return FunctionConfig(
+                language="python",
+                type=model.get("config", {}).get("type", ""),
+                runtime_version=model.get("config", {}).get(
+                    "runtime_version", "embedded"
+                ),
+                entry_point=model.get("config", {}).get(
+                    "entry_point", model.get("name")
+                ),
+            )
+
         function_config = super().get_function_config(model)
         if function_config is None:
             return None
 
-        configured_language = model.get("config", {}).get("language")
         if configured_language:
-            return replace(
-                function_config, language=str(configured_language).lower()
-            )
+            return replace(function_config, language=str(configured_language).lower())
         return function_config
 
     # RisingWave has no limitation on relation name length.

--- a/dbt/adapters/risingwave/relation.py
+++ b/dbt/adapters/risingwave/relation.py
@@ -44,17 +44,21 @@ class RisingWaveRelation(PostgresRelation):
         configured_language = model.get("config", {}).get("language")
         if configured_language and str(configured_language).lower() == "python":
             # dbt-core's native python function contract expects runtime_version and
-            # entry_point metadata, but RisingWave embedded Python UDFs do not use
-            # those fields. Provide adapter-local placeholders so we can still route
-            # the function to the python macro path.
+            # entry_point metadata, but RisingWave external Python UDFs do not use
+            # those fields directly. Provide adapter-local placeholders so we can
+            # still route the function to the python macro path while generating
+            # `AS ... USING LINK ...` SQL in the adapter macro.
+            remote_name = model.get("config", {}).get(
+                "remote_name", model.get("name")
+            )
             return FunctionConfig(
                 language="python",
                 type=model.get("config", {}).get("type", ""),
                 runtime_version=model.get("config", {}).get(
-                    "runtime_version", "embedded"
+                    "runtime_version", "external"
                 ),
                 entry_point=model.get("config", {}).get(
-                    "entry_point", model.get("name")
+                    "entry_point", remote_name
                 ),
             )
 

--- a/dbt/include/risingwave/macros/materializations/functions/scalar.sql
+++ b/dbt/include/risingwave/macros/materializations/functions/scalar.sql
@@ -33,3 +33,14 @@
     WITH ({{ options | join(', ') }})
     {%- endif %};
 {% endmacro %}
+
+{% macro risingwave__scalar_function_python(target_relation) %}
+    CREATE FUNCTION IF NOT EXISTS {{ target_relation.render() }} ({{ formatted_scalar_function_args_sql() }})
+    RETURNS {{ model.returns.data_type }}
+    {{ scalar_function_volatility_sql() }}
+    LANGUAGE PYTHON
+    AS
+    $$
+{{ model.compiled_code }}
+    $$;
+{% endmacro %}

--- a/dbt/include/risingwave/macros/materializations/functions/scalar.sql
+++ b/dbt/include/risingwave/macros/materializations/functions/scalar.sql
@@ -35,12 +35,22 @@
 {% endmacro %}
 
 {% macro risingwave__scalar_function_python(target_relation) %}
+    {% set link = model.config.get('link') %}
+    {% if not link %}
+        {{ exceptions.raise_compiler_error("RisingWave external Python UDFs require `config.link`.") }}
+    {% endif %}
+    {% set remote_name = model.config.get('remote_name', model.name) %}
+    {% set options = [] %}
+    {% if model.config.get('always_retry_on_network_error') %}
+        {% do options.append('always_retry_on_network_error = true') %}
+    {% endif %}
+
     CREATE FUNCTION IF NOT EXISTS {{ target_relation.render() }} ({{ formatted_scalar_function_args_sql() }})
     RETURNS {{ model.returns.data_type }}
     {{ scalar_function_volatility_sql() }}
-    LANGUAGE PYTHON
-    AS
-    $$
-{{ model.compiled_code }}
-    $$;
+    AS '{{ remote_name | replace("'", "''") }}'
+    USING LINK '{{ link | replace("'", "''") }}'
+    {%- if options | length > 0 %}
+    WITH ({{ options | join(', ') }})
+    {%- endif %};
 {% endmacro %}

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ This directory contains the adapter-specific documentation that used to be mixed
 ## Guides
 
 - [configuration.md](configuration.md): profile settings, model configuration, and sink options
-- [functions.md](functions.md): first-version SQL scalar function support and its limits
+- [functions.md](functions.md): first-version RisingWave function support and its limits
 - [zero-downtime-rebuilds.md](zero-downtime-rebuilds.md): zero-downtime rebuild flow for materialized views and views
 
 ## Start Here
@@ -14,5 +14,5 @@ If you are new to the adapter:
 
 1. Read the root [README.md](../README.md) for installation and basic project setup.
 2. Read [configuration.md](configuration.md) for RisingWave-specific configuration.
-3. Read [functions.md](functions.md) if you plan to manage SQL scalar UDFs with dbt.
+3. Read [functions.md](functions.md) if you plan to manage RisingWave scalar UDFs with dbt.
 4. Read [zero-downtime-rebuilds.md](zero-downtime-rebuilds.md) if you plan to use swap-based rebuilds.

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -8,6 +8,8 @@ This first version supports:
 
 - SQL scalar functions
 - JavaScript scalar functions through `config.language: javascript`
+- Python scalar functions through `config.language: python`
+  - with `config.runtime_version: embedded`
 - JavaScript async options through adapter config:
   - `async`
   - `batch`
@@ -102,6 +104,50 @@ Model usage:
 select {{ function('price_for_xlarge_js') }}(100::float8) as xlarge_price
 ```
 
+### Python Scalar Function
+
+Project layout:
+
+```text
+functions/
+  price_for_xlarge_py.sql
+  price_for_xlarge_py.yml
+models/
+  py_udf_example.sql
+```
+
+Function file:
+
+```sql
+import math
+
+def price_for_xlarge_py(price):
+    return math.fsum([price, price])
+```
+
+Function YAML:
+
+```yaml
+functions:
+  - name: price_for_xlarge_py
+    config:
+      language: python
+      runtime_version: embedded
+    arguments:
+      - name: price
+        data_type: float8
+    returns:
+      data_type: float8
+```
+
+Model usage:
+
+```sql
+{{ config(materialized='view') }}
+
+select {{ function('price_for_xlarge_py') }}(100::float8) as xlarge_price
+```
+
 ## First-Version Contract
 
 This adapter currently materializes SQL scalar functions with:
@@ -126,6 +172,14 @@ CREATE FUNCTION IF NOT EXISTS ... LANGUAGE JAVASCRIPT AS $$ ... $$;
 The exported JavaScript function should match the dbt function name.
 
 This uses an adapter-level workaround for current dbt-core limits. Upstream dbt function parsing currently only accepts `.sql` and `.py` files, so JavaScript UDFs are authored in `functions/*.sql` and switched to JavaScript with `config.language: javascript`.
+
+For embedded Python, `dbt-core`'s native `python` function contract expects fields such as `runtime_version` and `entry_point`, which do not match RisingWave embedded Python UDF syntax. So this adapter currently uses the same pattern for Python and authors embedded Python UDFs in `functions/*.sql` with `config.language: python`.
+
+Current Python-specific contract:
+
+- set `config.language: python`
+- set `config.runtime_version: embedded`
+- you do not need to set `entry_point`; the adapter defaults it to the function name
 
 ### JavaScript Async Options
 
@@ -159,13 +213,15 @@ This first version does not support:
 - aggregate functions
 - table functions
 - remote or external UDFs
-- embedded `python` UDFs
 - default arguments
 - native `.js` function resources in dbt-core
+- native `.py` function resources for RisingWave embedded Python UDFs
 
 ## Cluster Requirement
 
 JavaScript UDF creation depends on RisingWave having embedded JavaScript UDF support enabled. If the cluster disables `enable_embedded_javascript_udf`, dbt function creation will fail at execution time.
+
+Embedded Python UDF creation also depends on RisingWave having `enable_embedded_python_udf = true`. If the cluster disables embedded Python UDFs, dbt function creation will fail at execution time.
 
 The overload limitation is especially important. The adapter only treats a function name as a manageable dbt relation when that name maps to a single signature inside the schema.
 

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -8,8 +8,10 @@ This first version supports:
 
 - SQL scalar functions
 - JavaScript scalar functions through `config.language: javascript`
-- Python scalar functions through `config.language: python`
-  - with `config.runtime_version: embedded`
+- external Python scalar functions through `config.language: python`
+  - with `config.link: http://host:port`
+  - optional `config.remote_name`
+  - optional `config.always_retry_on_network_error`
 - JavaScript async options through adapter config:
   - `async`
   - `batch`
@@ -119,10 +121,8 @@ models/
 Function file:
 
 ```sql
-import math
-
-def price_for_xlarge_py(price):
-    return math.fsum([price, price])
+-- The adapter ignores the body for external Python UDFs.
+-- The real implementation lives in the external UDF server.
 ```
 
 Function YAML:
@@ -132,7 +132,7 @@ functions:
   - name: price_for_xlarge_py
     config:
       language: python
-      runtime_version: embedded
+      link: http://127.0.0.1:8815
     arguments:
       - name: price
         data_type: float8
@@ -173,13 +173,21 @@ The exported JavaScript function should match the dbt function name.
 
 This uses an adapter-level workaround for current dbt-core limits. Upstream dbt function parsing currently only accepts `.sql` and `.py` files, so JavaScript UDFs are authored in `functions/*.sql` and switched to JavaScript with `config.language: javascript`.
 
-For embedded Python, `dbt-core`'s native `python` function contract expects fields such as `runtime_version` and `entry_point`, which do not match RisingWave embedded Python UDF syntax. So this adapter currently uses the same pattern for Python and authors embedded Python UDFs in `functions/*.sql` with `config.language: python`.
+For external Python, `dbt-core`'s native `python` function contract still expects fields such as `runtime_version` and `entry_point`, but RisingWave external Python UDFs use `AS 'remote_name' USING LINK 'http://host:port'`. So this adapter authors external Python UDFs in `functions/*.sql` with `config.language: python` and adapter-specific config.
 
 Current Python-specific contract:
 
 - set `config.language: python`
-- set `config.runtime_version: embedded`
-- you do not need to set `entry_point`; the adapter defaults it to the function name
+- set `config.link`
+- optional `config.remote_name`; defaults to the dbt function name
+- optional `config.always_retry_on_network_error`
+- you do not need to set `runtime_version` or `entry_point`; the adapter fills placeholders for dbt-core validation
+
+Python UDFs are materialized as:
+
+```sql
+CREATE FUNCTION IF NOT EXISTS ... AS 'remote_name' USING LINK 'http://host:port';
+```
 
 ### JavaScript Async Options
 
@@ -212,16 +220,15 @@ This first version does not support:
 - overload-family management
 - aggregate functions
 - table functions
-- remote or external UDFs
 - default arguments
 - native `.js` function resources in dbt-core
-- native `.py` function resources for RisingWave embedded Python UDFs
+- native `.py` function resources for RisingWave external Python UDFs
 
 ## Cluster Requirement
 
 JavaScript UDF creation depends on RisingWave having embedded JavaScript UDF support enabled. If the cluster disables `enable_embedded_javascript_udf`, dbt function creation will fail at execution time.
 
-Embedded Python UDF creation also depends on RisingWave having `enable_embedded_python_udf = true`. If the cluster disables embedded Python UDFs, dbt function creation will fail at execution time.
+External Python UDF creation requires the configured UDF server link to be reachable from RisingWave. If the UDF server is down or unreachable, function creation or execution will fail at runtime.
 
 The overload limitation is especially important. The adapter only treats a function name as a manageable dbt relation when that name maps to a single signature inside the schema.
 


### PR DESCRIPTION
## Summary
- switch Python function support from embedded UDFs to RisingWave external Python scalar UDFs
- materialize `config.language: python` functions as `CREATE FUNCTION ... AS 'remote_name' USING LINK 'http://host:port'`
- document the external Python adapter contract: `link`, optional `remote_name`, and optional `always_retry_on_network_error`

