### PR TITLE
Support additive schema evolution for table_with_connector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,14 @@ jobs:
         image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
         ports:
           - 4566:4566
+        options: >-
+          --add-host=host.docker.internal:host-gateway
+
+    env:
+      JS_UDF_HTTP_BIND_HOST: 0.0.0.0
+      JS_UDF_HTTP_BASE_URL: http://host.docker.internal:18080
+      PY_UDF_SERVER_BIND_HOST: 0.0.0.0
+      PY_UDF_SERVER_URL: http://host.docker.internal:8815
 
     steps:
     - uses: actions/checkout@v3
@@ -84,10 +92,19 @@ jobs:
           target: dev
         EOF
     - name: Install dbt-risingwave globally
-      run: python3 -m pip install .
+      run: |
+        python3 -m pip install .
+        python3 -m pip install -r dbt_rw_nexmark/scripts/python_udf_server_requirements.txt
 
-    - name: dbt-run
-      run: dbt run
+    - name: Start UDF mock servers
+      run: |
+        python3 dbt_rw_nexmark/scripts/js_udf_http_server.py > /tmp/js_udf_http_server.log 2>&1 &
+        python3 dbt_rw_nexmark/scripts/python_udf_server.py > /tmp/python_udf_server.log 2>&1 &
+        timeout 30 bash -c 'until nc -z 127.0.0.1 18080; do sleep 1; done'
+        timeout 30 bash -c 'until nc -z 127.0.0.1 8815; do sleep 1; done'
+
+    - name: dbt-build
+      run: dbt build
       working-directory: dbt_rw_nexmark
 
     - name: dbt-doc

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ from {{ ref('events') }}
 | `incremental` | Batch-style incremental updates for tables. Prefer `materialized_view` when a streaming MV fits the workload. |
 | `connection` | Runs a full `CREATE CONNECTION` statement supplied by the model SQL. |
 | `source` | Runs a full `CREATE SOURCE` statement supplied by the model SQL. |
-| `table_with_connector` | Runs a full `CREATE TABLE ... WITH (...)` statement supplied by the model SQL. |
+| `table_with_connector` | Runs a full `CREATE TABLE ... WITH (...)` statement supplied by the model SQL. Supports explicit additive `ALTER TABLE ADD COLUMN` changes through `on_schema_change='append_new_columns'`. |
 | `sink` | Creates a sink, either from adapter configs or from a full SQL statement. |
 
 See [docs/configuration.md](docs/configuration.md) for adapter-specific configuration examples, including streaming session settings and background DDL.

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -387,6 +387,135 @@
     {% endif %}
 {% endmacro %}
 
+{% macro risingwave__validate_table_with_connector_on_schema_change(on_schema_change) %}
+  {% if on_schema_change is none %}
+    {{ return("ignore") }}
+  {% elif on_schema_change in ["ignore", "append_new_columns", "fail"] %}
+    {{ return(on_schema_change) }}
+  {% elif on_schema_change == "sync_all_columns" %}
+    {{ exceptions.raise_compiler_error("`table_with_connector` does not support `on_schema_change='sync_all_columns'`. Use `append_new_columns` for additive changes or run explicit RisingWave DDL for non-additive changes.") }}
+  {% else %}
+    {{ exceptions.raise_compiler_error("Invalid `on_schema_change` value for `table_with_connector`: " ~ on_schema_change) }}
+  {% endif %}
+{% endmacro %}
+
+{% macro risingwave__get_table_with_connector_additive_columns() %}
+  {% set additive_columns = config.get("additive_schema_evolution", none) %}
+
+  {# Alias in case users prefer a materialization-specific config name. #}
+  {% if additive_columns is none %}
+    {% set additive_columns = config.get("table_with_connector_add_columns", []) %}
+  {% endif %}
+
+  {% if additive_columns is mapping %}
+    {% set additive_columns = additive_columns.get("columns", []) %}
+  {% endif %}
+
+  {% if additive_columns is string %}
+    {{ exceptions.raise_compiler_error("`additive_schema_evolution` must be a list of column definitions, not a string.") }}
+  {% endif %}
+
+  {{ return(additive_columns) }}
+{% endmacro %}
+
+{% macro risingwave__render_table_with_connector_add_column(column_config) -%}
+  {% if column_config is not mapping %}
+    {{ exceptions.raise_compiler_error("Each `additive_schema_evolution` entry must be a dictionary with `name` and `data_type`.") }}
+  {% endif %}
+
+  {% set column_name = column_config.get("name", none) %}
+  {% set data_type = column_config.get("data_type", column_config.get("type", none)) %}
+  {% set default_expr = column_config.get("default", none) %}
+  {% set not_null = column_config.get("not_null", false) %}
+
+  {% if column_name is none or column_name | trim == "" %}
+    {{ exceptions.raise_compiler_error("Each `additive_schema_evolution` entry must include a non-empty `name`.") }}
+  {% endif %}
+
+  {% if data_type is none or data_type | trim == "" %}
+    {{ exceptions.raise_compiler_error("`additive_schema_evolution` column `" ~ column_name ~ "` must include `data_type`.") }}
+  {% endif %}
+
+  {% if column_config.get("primary_key", false) %}
+    {{ exceptions.raise_compiler_error("`table_with_connector` additive schema evolution cannot add primary-key columns: " ~ column_name) }}
+  {% endif %}
+
+  {% if column_config.get("generated", false) %}
+    {{ exceptions.raise_compiler_error("`table_with_connector` additive schema evolution cannot add generated columns: " ~ column_name) }}
+  {% endif %}
+
+  {% if not_null and default_expr is none %}
+    {{ exceptions.raise_compiler_error("`table_with_connector` additive schema evolution cannot add NOT NULL column `" ~ column_name ~ "` without a DEFAULT expression.") }}
+  {% endif %}
+
+  {%- if column_config.get("quote", false) -%}
+    {{ adapter.quote(column_name) }}
+  {%- else -%}
+    {{ column_name }}
+  {%- endif -%}
+  {{ " " ~ data_type }}
+  {%- if default_expr is not none %} default {{ default_expr }}{% endif -%}
+  {%- if not_null %} not null{% endif -%}
+{%- endmacro %}
+
+{% macro risingwave__table_with_connector_missing_additive_columns(target_relation, additive_columns) %}
+  {% set existing_column_names = [] %}
+  {% for existing_column in adapter.get_columns_in_relation(target_relation) %}
+    {% do existing_column_names.append(existing_column.name | lower) %}
+  {% endfor %}
+
+  {% set missing_columns = [] %}
+  {% for column_config in additive_columns %}
+    {% if column_config is not mapping %}
+      {{ exceptions.raise_compiler_error("Each `additive_schema_evolution` entry must be a dictionary with `name` and `data_type`.") }}
+    {% endif %}
+
+    {% set column_name = column_config.get("name", none) %}
+    {% if column_name is none or column_name | trim == "" %}
+      {{ exceptions.raise_compiler_error("Each `additive_schema_evolution` entry must include a non-empty `name`.") }}
+    {% endif %}
+
+    {% if column_name | lower not in existing_column_names %}
+      {% do missing_columns.append(column_config) %}
+    {% endif %}
+  {% endfor %}
+
+  {{ return(missing_columns) }}
+{% endmacro %}
+
+{% macro risingwave__handle_table_with_connector_on_schema_change(target_relation) %}
+  {% set on_schema_change = risingwave__validate_table_with_connector_on_schema_change(config.get("on_schema_change", "ignore")) %}
+
+  {% if on_schema_change == "ignore" %}
+    {{ return(false) }}
+  {% endif %}
+
+  {% set additive_columns = risingwave__get_table_with_connector_additive_columns() %}
+
+  {% if additive_columns | length == 0 %}
+    {% if on_schema_change == "append_new_columns" %}
+      {{ exceptions.warn("`table_with_connector` cannot infer new columns from raw CREATE TABLE SQL. Configure `additive_schema_evolution` to enable additive schema evolution.") }}
+    {% endif %}
+    {{ return(false) }}
+  {% endif %}
+
+  {% set missing_columns = risingwave__table_with_connector_missing_additive_columns(target_relation, additive_columns) %}
+
+  {% if missing_columns | length == 0 %}
+    {{ return(false) }}
+  {% elif on_schema_change == "fail" %}
+    {% set missing_column_names = missing_columns | map(attribute="name") | join(", ") %}
+    {{ exceptions.raise_compiler_error("`table_with_connector` schema changes detected for " ~ target_relation ~ ": missing columns [" ~ missing_column_names ~ "]. Set `on_schema_change='append_new_columns'` to apply additive changes.") }}
+  {% elif on_schema_change == "append_new_columns" %}
+    {% call statement('table_with_connector_add_columns') -%}
+      {% for column_config in missing_columns %}
+        alter table {{ target_relation }} add column {{ risingwave__render_table_with_connector_add_column(column_config) }};
+      {% endfor %}
+    {%- endcall %}
+    {{ return(true) }}
+  {% endif %}
+{% endmacro %}
+
 {% macro risingwave__truncate_relation(relation) -%}
   {% call statement('truncate_relation') -%}
     delete from {{ relation }}

--- a/dbt/include/risingwave/macros/materializations/table_with_connector.sql
+++ b/dbt/include/risingwave/macros/materializations/table_with_connector.sql
@@ -23,7 +23,16 @@
 
     {{ create_indexes(target_relation) }}
   {% else %}
+    {% set applied_table_schema_change = risingwave__handle_table_with_connector_on_schema_change(target_relation) %}
     {{ risingwave__handle_on_configuration_change(old_relation, target_relation) }}
+    {% if applied_table_schema_change %}
+      {% do store_raw_result(
+          name="main",
+          message="ALTER_TABLE",
+          code="ALTER_TABLE",
+          rows_affected="-1"
+      ) %}
+    {% endif %}
   {% endif %}
 
   {% do persist_docs(target_relation, model) %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -198,6 +198,60 @@ Supported values:
 | `continue` | Keep going and emit a warning. |
 | `fail` | Stop the run with an error. |
 
+### Additive Schema Evolution for `table_with_connector`
+
+`table_with_connector` normally runs the model's raw `CREATE TABLE ... WITH (...)` SQL only when the table does not exist, or when dbt is run with `--full-refresh`. If the table already exists, the adapter does not re-run the connector DDL because that can recreate external connector state.
+
+For additive table changes, the adapter supports a conservative `ALTER TABLE ADD COLUMN` path:
+
+```sql
+{{ config(
+    materialized='table_with_connector',
+    on_schema_change='append_new_columns',
+    additive_schema_evolution=[
+      {'name': 'source_ts', 'data_type': 'timestamp'},
+      {'name': 'score', 'data_type': 'double precision', 'default': '0.0'}
+    ]
+) }}
+
+CREATE TABLE {{ this }} (
+    id int,
+    payload jsonb,
+    source_ts timestamp,
+    score double precision
+) WITH (
+    appendonly = 'true'
+);
+```
+
+When the table already exists, dbt checks the configured `additive_schema_evolution` columns against RisingWave's catalog and runs one `ALTER TABLE ... ADD COLUMN` statement for each missing column.
+
+Supported values for `on_schema_change` on `table_with_connector`:
+
+| Value | Behavior |
+| --- | --- |
+| `ignore` | Default. Keep the existing table schema unchanged. |
+| `append_new_columns` | Add missing columns listed in `additive_schema_evolution`. |
+| `fail` | Fail if any column listed in `additive_schema_evolution` is missing. |
+| `sync_all_columns` | Not supported for `table_with_connector`. |
+
+Column entries support:
+
+| Key | Required | Description |
+| --- | --- | --- |
+| `name` | Yes | Column name. |
+| `data_type` | Yes | RisingWave SQL type used in `ALTER TABLE ADD COLUMN`. |
+| `default` | No | SQL expression emitted after `DEFAULT`. |
+| `not_null` | No | Emits `NOT NULL`. Must be used with `default`. |
+| `quote` | No | Quote the column identifier. |
+
+Limitations:
+
+- The adapter does not infer new columns from the raw `CREATE TABLE` SQL. Configure `additive_schema_evolution` explicitly.
+- Only additive columns are supported. Primary-key changes, generated columns, column drops, type changes, connector options, watermark clauses, and table properties are not changed.
+- Existing downstream materialized views and sinks continue running, but their output schemas do not automatically include newly added columns. Update downstream dbt models separately when they should consume the new column.
+- RisingWave does not support this path for webhook tables.
+
 ### Zero-Downtime Rebuilds
 
 `materialized_view` and `view` support swap-based zero-downtime rebuilds.


### PR DESCRIPTION
## Summary

Adds a conservative additive schema evolution path for `table_with_connector` models.

When an existing `table_with_connector` relation is found, users can opt into `on_schema_change='append_new_columns'` and provide explicit `additive_schema_evolution` column definitions. The adapter compares those definitions with the existing RisingWave table schema and applies missing columns using `ALTER TABLE ... ADD COLUMN`.

## Contract

- Default behavior remains `on_schema_change='ignore'`.
- `append_new_columns` only adds explicitly configured columns.
- `fail` raises if configured additive columns are missing.
- `sync_all_columns` is rejected for `table_with_connector`.
- The adapter does not infer schema changes from raw `CREATE TABLE` SQL.
- Non-additive changes, primary-key changes, generated columns, connector options, watermarks, and table properties are out of scope.

## Validation

- `git diff --cached --check`
- Local live validation was run earlier against RisingWave on `localhost:4566` with a temporary dbt project and `psql`, confirming `ALTER TABLE ADD COLUMN` is applied and existing rows are preserved.

## Note

Functional tests are intentionally not included in this PR. We will add coverage separately using the dbt adapter test framework.
