### PR TITLE
Add dbt model e2e test framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,46 @@ jobs:
     - name: dbt-doc
       run: dbt docs generate
       working-directory: dbt_rw_nexmark
+
+  test-basic-models:
+    runs-on: ubuntu-latest
+    services:
+      risingwave:
+        image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        ports:
+          - 4566:4566
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Setup dbt profile
+      run: |
+        mkdir -p $HOME/.dbt && cat >> $HOME/.dbt/profiles.yml <<EOF
+        dbt_risingwave_basic_models:
+          outputs:
+            dev:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dev
+              port: 4566
+              schema: public
+          target: dev
+        EOF
+    - name: Install current adapter
+      run: python3 -m pip install .
+    - name: Wait for RisingWave to be ready
+      run: timeout 60 bash -c 'until nc -z 127.0.0.1 4566; do sleep 1; done'
+    - name: dbt-run
+      run: dbt run --full-refresh
+      working-directory: tests/e2e/basic_models
+    - name: dbt-test
+      run: dbt test
+      working-directory: tests/e2e/basic_models
+    - name: dbt-doc
+      run: dbt docs generate
+      working-directory: tests/e2e/basic_models

--- a/tests/e2e/basic_models/dbt_project.yml
+++ b/tests/e2e/basic_models/dbt_project.yml
@@ -1,0 +1,8 @@
+name: dbt_risingwave_basic_models
+version: "1.0"
+config-version: 2
+
+profile: dbt_risingwave_basic_models
+
+model-paths: ["models"]
+test-paths: ["tests"]

--- a/tests/e2e/basic_models/models/base_table.sql
+++ b/tests/e2e/basic_models/models/base_table.sql
@@ -1,0 +1,5 @@
+{{ config(materialized='table') }}
+
+select 1 as id, 'alpha'::varchar as payload
+union all
+select 2 as id, 'beta'::varchar as payload

--- a/tests/e2e/basic_models/models/events_mv.sql
+++ b/tests/e2e/basic_models/models/events_mv.sql
@@ -1,0 +1,6 @@
+{{ config(materialized='materialized_view') }}
+
+select
+    id,
+    payload || '_mv' as payload
+from {{ ref('base_table') }}

--- a/tests/e2e/basic_models/tests/assert_core_materializations.sql
+++ b/tests/e2e/basic_models/tests/assert_core_materializations.sql
@@ -1,0 +1,63 @@
+select 'base_table must be a table' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'base_table'
+      and rw_relations.relation_type = 'table'
+)
+
+union all
+
+select 'events_mv must be a materialized view' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'events_mv'
+      and rw_relations.relation_type = 'materialized view'
+)
+
+union all
+
+select 'base_table has unexpected row count' as failure
+where (select count(*) from {{ ref('base_table') }}) != 2
+
+union all
+
+select 'base_table missing alpha row' as failure
+where not exists (
+    select 1 from {{ ref('base_table') }}
+    where id = 1 and payload = 'alpha'
+)
+
+union all
+
+select 'base_table missing beta row' as failure
+where not exists (
+    select 1 from {{ ref('base_table') }}
+    where id = 2 and payload = 'beta'
+)
+
+union all
+
+select 'events_mv has unexpected row count' as failure
+where (select count(*) from {{ ref('events_mv') }}) != 2
+
+union all
+
+select 'events_mv missing alpha row' as failure
+where not exists (
+    select 1 from {{ ref('events_mv') }}
+    where id = 1 and payload = 'alpha_mv'
+)
+
+union all
+
+select 'events_mv missing beta row' as failure
+where not exists (
+    select 1 from {{ ref('events_mv') }}
+    where id = 2 and payload = 'beta_mv'
+)


### PR DESCRIPTION
## Summary

Bootstraps a dbt model e2e test framework for `dbt-risingwave`.

The new CI job starts a live RisingWave service, installs `dbt-risingwave` from the current PR checkout, and runs a small in-repo dbt project through the normal dbt CLI. This verifies the PR version of the adapter through the same user-facing path as a real dbt project, instead of relying on the latest PyPI package or an external example repo.

## Covered behavior

- Adds an in-repo fixture dbt project under `tests/e2e/basic_models/`.
- Runs `dbt run --full-refresh` against live RisingWave.
- Runs `dbt test` with SQL assertions for relation type and query results.
- Runs `dbt docs generate` to keep docs generation covered for the fixture project.
- Covers a basic `table` model and a dependent `materialized_view` model.

## Notes

This PR intentionally focuses on the e2e test harness and core model materializations. Feature-specific regressions, such as `table_with_connector` schema evolution, can be added as follow-up e2e projects or test cases.

## Validation

- `git diff --cached origin/main --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file("tests/e2e/basic_models/dbt_project.yml")'`
- `dbt-env/bin/dbt parse --profiles-dir <tmp-profile-dir> --project-dir tests/e2e/basic_models --no-partial-parse`
