### PR TITLE
Add view coverage to basic dbt model e2e

### DIFF
--- a/tests/e2e/basic_models/models/base_view.sql
+++ b/tests/e2e/basic_models/models/base_view.sql
@@ -1,0 +1,6 @@
+{{ config(materialized='view') }}
+
+select
+    id,
+    payload || '_view' as payload
+from {{ ref('base_table') }}

--- a/tests/e2e/basic_models/models/events_mv.sql
+++ b/tests/e2e/basic_models/models/events_mv.sql
@@ -3,4 +3,4 @@
 select
     id,
     payload || '_mv' as payload
-from {{ ref('base_table') }}
+from {{ ref('base_view') }}

--- a/tests/e2e/basic_models/tests/assert_core_materializations.sql
+++ b/tests/e2e/basic_models/tests/assert_core_materializations.sql
@@ -10,6 +10,18 @@ where not exists (
 
 union all
 
+select 'base_view must be a view' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'base_view'
+      and rw_relations.relation_type = 'view'
+)
+
+union all
+
 select 'events_mv must be a materialized view' as failure
 where not exists (
     select 1
@@ -43,6 +55,27 @@ where not exists (
 
 union all
 
+select 'base_view has unexpected row count' as failure
+where (select count(*) from {{ ref('base_view') }}) != 2
+
+union all
+
+select 'base_view missing alpha row' as failure
+where not exists (
+    select 1 from {{ ref('base_view') }}
+    where id = 1 and payload = 'alpha_view'
+)
+
+union all
+
+select 'base_view missing beta row' as failure
+where not exists (
+    select 1 from {{ ref('base_view') }}
+    where id = 2 and payload = 'beta_view'
+)
+
+union all
+
 select 'events_mv has unexpected row count' as failure
 where (select count(*) from {{ ref('events_mv') }}) != 2
 
@@ -51,7 +84,7 @@ union all
 select 'events_mv missing alpha row' as failure
 where not exists (
     select 1 from {{ ref('events_mv') }}
-    where id = 1 and payload = 'alpha_mv'
+    where id = 1 and payload = 'alpha_view_mv'
 )
 
 union all
@@ -59,5 +92,5 @@ union all
 select 'events_mv missing beta row' as failure
 where not exists (
     select 1 from {{ ref('events_mv') }}
-    where id = 2 and payload = 'beta_mv'
+    where id = 2 and payload = 'beta_view_mv'
 )


### PR DESCRIPTION
## Summary

Adds `view` materialization coverage to the in-repo dbt model e2e project.

This keeps the test on the user-facing dbt CLI path introduced by the e2e framework: `dbt run --full-refresh`, `dbt test`, and `dbt docs generate` against live RisingWave in CI.

## Covered behavior

- Adds a `base_view` model materialized as `view`.
- Changes the existing `events_mv` materialized view to depend on `base_view`, covering a `table -> view -> materialized_view` chain.
- Extends the singular dbt test to assert:
  - `base_table` is a table
  - `base_view` is a view
  - `events_mv` is a materialized view
  - all three relations return the expected rows

## Validation

- `git diff --check`
- `dbt-env/bin/dbt parse --profiles-dir <tmp-profile-dir> --project-dir tests/e2e/basic_models --no-partial-parse`

Local live RisingWave was not available on `localhost:4566`, so the full `dbt run/test/docs` validation is left to CI.
