### PR TITLE
test: add table_with_connector e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,3 +153,67 @@ jobs:
     - name: dbt-doc
       run: dbt docs generate
       working-directory: tests/e2e/basic_models
+
+  test-table-with-connector:
+    runs-on: ubuntu-latest
+    services:
+      risingwave:
+        image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        ports:
+          - 4566:4566
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Setup dbt profile
+      run: |
+        mkdir -p $HOME/.dbt && cat >> $HOME/.dbt/profiles.yml <<EOF
+        dbt_risingwave_table_with_connector:
+          outputs:
+            dev:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dev
+              port: 4566
+              schema: public
+          target: dev
+        EOF
+    - name: Install current adapter
+      run: python3 -m pip install .
+    - name: Wait for RisingWave to be ready
+      run: timeout 60 bash -c 'until nc -z 127.0.0.1 4566; do sleep 1; done'
+    - name: dbt-run-create
+      run: dbt run --full-refresh
+      working-directory: tests/e2e/table_with_connector
+    - name: dbt-test-created-schema
+      run: dbt test
+      working-directory: tests/e2e/table_with_connector
+    - name: dbt-run-existing-relation
+      run: dbt run
+      working-directory: tests/e2e/table_with_connector
+    - name: dbt-test-existing-relation
+      run: dbt test
+      working-directory: tests/e2e/table_with_connector
+    - name: insert-pre-evolution-row
+      run: dbt run-operation insert_pre_evolution_row
+      working-directory: tests/e2e/table_with_connector
+    - name: dbt-run-additive-columns
+      run: dbt run
+      working-directory: tests/e2e/table_with_connector
+      env:
+        DBT_RW_TWC_ADD_EXTRA: "true"
+    - name: dbt-test-additive-columns
+      run: dbt test
+      working-directory: tests/e2e/table_with_connector
+      env:
+        DBT_RW_TWC_EXPECT_EXTRA: "true"
+    - name: dbt-doc
+      run: dbt docs generate
+      working-directory: tests/e2e/table_with_connector
+      env:
+        DBT_RW_TWC_ADD_EXTRA: "true"

--- a/tests/e2e/table_with_connector/dbt_project.yml
+++ b/tests/e2e/table_with_connector/dbt_project.yml
@@ -1,0 +1,9 @@
+name: dbt_risingwave_table_with_connector
+version: "1.0"
+config-version: 2
+
+profile: dbt_risingwave_table_with_connector
+
+model-paths: ["models"]
+macro-paths: ["macros"]
+test-paths: ["tests"]

--- a/tests/e2e/table_with_connector/macros/insert_pre_evolution_row.sql
+++ b/tests/e2e/table_with_connector/macros/insert_pre_evolution_row.sql
@@ -1,0 +1,12 @@
+{% macro insert_pre_evolution_row() %}
+  {% set relation = api.Relation.create(
+      identifier='connector_events',
+      schema=target.schema,
+      database=target.database,
+      type='table'
+  ) %}
+
+  {% call statement('insert_pre_evolution_row') %}
+    insert into {{ relation }} values (101, 'before_add_column');
+  {% endcall %}
+{% endmacro %}

--- a/tests/e2e/table_with_connector/models/connector_events.sql
+++ b/tests/e2e/table_with_connector/models/connector_events.sql
@@ -1,0 +1,27 @@
+{% set enable_additive_columns = env_var('DBT_RW_TWC_ADD_EXTRA', 'false') == 'true' %}
+{% set on_schema_change = 'append_new_columns' if enable_additive_columns else 'ignore' %}
+{% if enable_additive_columns %}
+  {% set additive_columns = [
+      {'name': 'source_tag', 'data_type': 'varchar'},
+      {'name': 'score', 'data_type': 'integer'}
+  ] %}
+{% else %}
+  {% set additive_columns = [] %}
+{% endif %}
+
+{{ config(
+    materialized='table_with_connector',
+    on_schema_change=on_schema_change,
+    additive_schema_evolution=additive_columns
+) }}
+
+CREATE TABLE {{ this }} (
+    id int,
+    payload varchar
+    {% if enable_additive_columns -%}
+    , source_tag varchar
+    , score int
+    {%- endif %}
+) WITH (
+    appendonly = 'true'
+);

--- a/tests/e2e/table_with_connector/tests/assert_table_with_connector_schema.sql
+++ b/tests/e2e/table_with_connector/tests/assert_table_with_connector_schema.sql
@@ -1,0 +1,135 @@
+{% set expect_extra_columns = env_var('DBT_RW_TWC_EXPECT_EXTRA', 'false') == 'true' %}
+
+select 'connector_events must be a table' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'connector_events'
+      and rw_relations.relation_type = 'table'
+)
+
+union all
+
+select 'connector_events missing id column' as failure
+where not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = '{{ target.schema }}'
+      and table_name = 'connector_events'
+      and column_name = 'id'
+)
+
+union all
+
+select 'connector_events missing payload column' as failure
+where not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = '{{ target.schema }}'
+      and table_name = 'connector_events'
+      and column_name = 'payload'
+)
+
+{% if expect_extra_columns %}
+
+union all
+
+select 'connector_events should preserve rows created before additive schema evolution' as failure
+where not exists (
+    select 1
+    from {{ ref('connector_events') }}
+    where id = 101
+      and payload = 'before_add_column'
+)
+
+union all
+
+select 'connector_events missing source_tag column after additive schema evolution' as failure
+where not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = '{{ target.schema }}'
+      and table_name = 'connector_events'
+      and column_name = 'source_tag'
+)
+
+union all
+
+select 'connector_events missing score column after additive schema evolution' as failure
+where not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = '{{ target.schema }}'
+      and table_name = 'connector_events'
+      and column_name = 'score'
+)
+
+union all
+
+select 'connector_events preserved row should expose NULL source_tag after add column' as failure
+where not exists (
+    select 1
+    from {{ ref('connector_events') }}
+    where id = 101
+      and payload = 'before_add_column'
+      and source_tag is null
+)
+
+union all
+
+select 'connector_events preserved row should expose NULL score after add column' as failure
+where not exists (
+    select 1
+    from {{ ref('connector_events') }}
+    where id = 101
+      and payload = 'before_add_column'
+      and score is null
+)
+
+union all
+
+select 'connector_events has unexpected column count after additive schema evolution' as failure
+where (
+    select count(*)
+    from information_schema.columns
+    where table_schema = '{{ target.schema }}'
+      and table_name = 'connector_events'
+) != 4
+
+{% else %}
+
+union all
+
+select 'connector_events should not have source_tag before additive schema evolution' as failure
+where exists (
+    select 1
+    from information_schema.columns
+    where table_schema = '{{ target.schema }}'
+      and table_name = 'connector_events'
+      and column_name = 'source_tag'
+)
+
+union all
+
+select 'connector_events should not have score before additive schema evolution' as failure
+where exists (
+    select 1
+    from information_schema.columns
+    where table_schema = '{{ target.schema }}'
+      and table_name = 'connector_events'
+      and column_name = 'score'
+)
+
+union all
+
+select 'connector_events has unexpected column count before additive schema evolution' as failure
+where (
+    select count(*)
+    from information_schema.columns
+    where table_schema = '{{ target.schema }}'
+      and table_name = 'connector_events'
+) != 2
+
+{% endif %}


### PR DESCRIPTION
## Summary
- add a dedicated dbt CLI e2e fixture for `table_with_connector`
- validate initial table creation and the existing-relation no-op path
- validate additive `append_new_columns` by re-running the model with extra configured columns and asserting the catalog schema
- add a CI job that runs the fixture with live RisingWave via `dbt run`, `dbt test`, and `dbt docs generate`

## Validation
- `git diff --check`
- `dbt parse --profiles-dir <tmp> --project-dir tests/e2e/table_with_connector --no-partial-parse`
- `DBT_RW_TWC_ADD_EXTRA=true dbt parse --profiles-dir <tmp> --project-dir tests/e2e/table_with_connector --no-partial-parse`

Local RisingWave on `localhost:4566` was unavailable, so live execution is covered by CI.