### PR TITLE
test: add sink e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,3 +217,52 @@ jobs:
       working-directory: tests/e2e/table_with_connector
       env:
         DBT_RW_TWC_ADD_EXTRA: "true"
+
+  test-sinks:
+    runs-on: ubuntu-latest
+    services:
+      risingwave:
+        image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        ports:
+          - 4566:4566
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Setup dbt profile
+      run: |
+        mkdir -p $HOME/.dbt && cat >> $HOME/.dbt/profiles.yml <<EOF
+        dbt_risingwave_sinks:
+          outputs:
+            dev:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dev
+              port: 4566
+              schema: public
+          target: dev
+        EOF
+    - name: Install current adapter
+      run: python3 -m pip install .
+    - name: Wait for RisingWave to be ready
+      run: timeout 60 bash -c 'until nc -z 127.0.0.1 4566; do sleep 1; done'
+    - name: dbt-run
+      run: dbt run --full-refresh
+      working-directory: tests/e2e/sinks
+    - name: dbt-test
+      run: dbt test
+      working-directory: tests/e2e/sinks
+    - name: dbt-run-existing-relations
+      run: dbt run
+      working-directory: tests/e2e/sinks
+    - name: dbt-test-existing-relations
+      run: dbt test
+      working-directory: tests/e2e/sinks
+    - name: dbt-doc
+      run: dbt docs generate
+      working-directory: tests/e2e/sinks

--- a/tests/e2e/sinks/dbt_project.yml
+++ b/tests/e2e/sinks/dbt_project.yml
@@ -1,0 +1,8 @@
+name: dbt_risingwave_sinks
+version: "1.0"
+config-version: 2
+
+profile: dbt_risingwave_sinks
+
+model-paths: ["models"]
+test-paths: ["tests"]

--- a/tests/e2e/sinks/models/managed_blackhole_sink.sql
+++ b/tests/e2e/sinks/models/managed_blackhole_sink.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized='sink',
+    connector='blackhole',
+    connector_parameters={
+      'type': 'append-only',
+      'force_append_only': 'true'
+    }
+) }}
+
+select
+    id,
+    payload
+from {{ ref('sink_source_mv') }}

--- a/tests/e2e/sinks/models/raw_blackhole_sink.sql
+++ b/tests/e2e/sinks/models/raw_blackhole_sink.sql
@@ -1,0 +1,12 @@
+{{ config(materialized='sink') }}
+
+create sink {{ this }}
+as select
+    id,
+    payload
+from {{ ref('sink_source_mv') }}
+with (
+    connector = 'blackhole',
+    type = 'append-only',
+    force_append_only = 'true'
+);

--- a/tests/e2e/sinks/models/sink_source_mv.sql
+++ b/tests/e2e/sinks/models/sink_source_mv.sql
@@ -1,0 +1,6 @@
+{{ config(materialized='materialized_view') }}
+
+select
+    id,
+    payload || '_mv' as payload
+from {{ ref('sink_source_table') }}

--- a/tests/e2e/sinks/models/sink_source_table.sql
+++ b/tests/e2e/sinks/models/sink_source_table.sql
@@ -1,0 +1,5 @@
+{{ config(materialized='table') }}
+
+select 1 as id, 'alpha'::varchar as payload
+union all
+select 2 as id, 'beta'::varchar as payload

--- a/tests/e2e/sinks/tests/assert_sink_materializations.sql
+++ b/tests/e2e/sinks/tests/assert_sink_materializations.sql
@@ -1,0 +1,66 @@
+select 'sink_source_table must be a table' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'sink_source_table'
+      and rw_relations.relation_type = 'table'
+)
+
+union all
+
+select 'sink_source_mv must be a materialized view' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'sink_source_mv'
+      and rw_relations.relation_type = 'materialized view'
+)
+
+union all
+
+select 'managed_blackhole_sink must be a sink' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'managed_blackhole_sink'
+      and rw_relations.relation_type = 'sink'
+)
+
+union all
+
+select 'raw_blackhole_sink must be a sink' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'raw_blackhole_sink'
+      and rw_relations.relation_type = 'sink'
+)
+
+union all
+
+select 'sink_source_mv has unexpected row count' as failure
+where (select count(*) from {{ ref('sink_source_mv') }}) != 2
+
+union all
+
+select 'sink_source_mv missing alpha row' as failure
+where not exists (
+    select 1 from {{ ref('sink_source_mv') }}
+    where id = 1 and payload = 'alpha_mv'
+)
+
+union all
+
+select 'sink_source_mv missing beta row' as failure
+where not exists (
+    select 1 from {{ ref('sink_source_mv') }}
+    where id = 2 and payload = 'beta_mv'
+)


### PR DESCRIPTION
## Summary
- add a dedicated dbt CLI e2e fixture for `sink` materialization
- cover adapter-managed sink DDL with `connector` config and raw SQL sink DDL without connector config
- use RisingWave `blackhole` sinks to avoid external dependencies
- add a CI job that runs the fixture with live RisingWave via `dbt run --full-refresh`, `dbt test`, a second no-op `dbt run`, and `dbt docs generate`

## Validation
- `git diff --check`
- `dbt parse --profiles-dir <tmp> --project-dir tests/e2e/sinks --no-partial-parse`

Local RisingWave on `localhost:4566` was unavailable, so live execution is covered by CI.