### PR TITLE
test: add incremental e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,3 +266,73 @@ jobs:
     - name: dbt-doc
       run: dbt docs generate
       working-directory: tests/e2e/sinks
+
+  test-incremental:
+    runs-on: ubuntu-latest
+    services:
+      risingwave:
+        image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        ports:
+          - 4566:4566
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Setup dbt profile
+      run: |
+        mkdir -p $HOME/.dbt && cat >> $HOME/.dbt/profiles.yml <<EOF
+        dbt_risingwave_incremental:
+          outputs:
+            dev:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dev
+              port: 4566
+              schema: public
+          target: dev
+        EOF
+    - name: Install current adapter
+      run: python3 -m pip install .
+    - name: Wait for RisingWave to be ready
+      run: timeout 60 bash -c 'until nc -z 127.0.0.1 4566; do sleep 1; done'
+    - name: setup-initial-source
+      run: dbt run-operation setup_initial_incremental_source
+      working-directory: tests/e2e/incremental
+    - name: dbt-run-initial
+      run: dbt run --full-refresh
+      working-directory: tests/e2e/incremental
+    - name: dbt-test-initial
+      run: dbt test
+      working-directory: tests/e2e/incremental
+      env:
+        DBT_RW_INCREMENTAL_EXPECT_STAGE: initial
+    - name: append-incremental-source
+      run: dbt run-operation append_incremental_source
+      working-directory: tests/e2e/incremental
+    - name: dbt-run-incremental
+      run: dbt run
+      working-directory: tests/e2e/incremental
+    - name: dbt-test-incremental
+      run: dbt test
+      working-directory: tests/e2e/incremental
+      env:
+        DBT_RW_INCREMENTAL_EXPECT_STAGE: incremental
+    - name: reset-source-for-full-refresh
+      run: dbt run-operation reset_incremental_source_for_full_refresh
+      working-directory: tests/e2e/incremental
+    - name: dbt-run-full-refresh
+      run: dbt run --full-refresh
+      working-directory: tests/e2e/incremental
+    - name: dbt-test-full-refresh
+      run: dbt test
+      working-directory: tests/e2e/incremental
+      env:
+        DBT_RW_INCREMENTAL_EXPECT_STAGE: full_refresh
+    - name: dbt-doc
+      run: dbt docs generate
+      working-directory: tests/e2e/incremental

--- a/tests/e2e/incremental/dbt_project.yml
+++ b/tests/e2e/incremental/dbt_project.yml
@@ -1,0 +1,9 @@
+name: dbt_risingwave_incremental
+version: "1.0"
+config-version: 2
+
+profile: dbt_risingwave_incremental
+
+model-paths: ["models"]
+macro-paths: ["macros"]
+test-paths: ["tests"]

--- a/tests/e2e/incremental/macros/incremental_source.sql
+++ b/tests/e2e/incremental/macros/incremental_source.sql
@@ -1,0 +1,49 @@
+{% macro incremental_source_relation() %}
+  {{ return(api.Relation.create(
+      identifier='incremental_input',
+      schema=target.schema,
+      database=target.database,
+      type='table'
+  )) }}
+{% endmacro %}
+
+{% macro setup_initial_incremental_source() %}
+  {% set relation = incremental_source_relation() %}
+
+  {% call statement('setup_initial_incremental_source') %}
+    drop table if exists {{ relation }};
+    create table {{ relation }} (
+      id int,
+      payload varchar,
+      batch_id int
+    );
+    insert into {{ relation }} values
+      (1, 'alpha', 1),
+      (2, 'beta', 1);
+  {% endcall %}
+{% endmacro %}
+
+{% macro append_incremental_source() %}
+  {% set relation = incremental_source_relation() %}
+
+  {% call statement('append_incremental_source') %}
+    insert into {{ relation }} values
+      (3, 'gamma', 2);
+  {% endcall %}
+{% endmacro %}
+
+{% macro reset_incremental_source_for_full_refresh() %}
+  {% set relation = incremental_source_relation() %}
+
+  {% call statement('reset_incremental_source_for_full_refresh') %}
+    drop table if exists {{ relation }};
+    create table {{ relation }} (
+      id int,
+      payload varchar,
+      batch_id int
+    );
+    insert into {{ relation }} values
+      (10, 'reset_alpha', 3),
+      (11, 'reset_beta', 3);
+  {% endcall %}
+{% endmacro %}

--- a/tests/e2e/incremental/models/incremental_events.sql
+++ b/tests/e2e/incremental/models/incremental_events.sql
@@ -1,0 +1,13 @@
+{{ config(materialized='incremental') }}
+
+{% set input_relation = incremental_source_relation() %}
+
+select
+    id,
+    payload,
+    batch_id
+from {{ input_relation }}
+
+{% if is_incremental() %}
+where id > (select coalesce(max(id), 0) from {{ this }})
+{% endif %}

--- a/tests/e2e/incremental/tests/assert_incremental_events.sql
+++ b/tests/e2e/incremental/tests/assert_incremental_events.sql
@@ -1,0 +1,94 @@
+{% set expected_stage = env_var('DBT_RW_INCREMENTAL_EXPECT_STAGE', 'initial') %}
+
+{% if expected_stage not in ['initial', 'incremental', 'full_refresh'] %}
+  {{ exceptions.raise_compiler_error("Invalid DBT_RW_INCREMENTAL_EXPECT_STAGE: " ~ expected_stage) }}
+{% endif %}
+
+select 'incremental_events must be a table' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'incremental_events'
+      and rw_relations.relation_type = 'table'
+)
+
+{% if expected_stage == 'initial' %}
+
+union all
+
+select 'initial incremental_events row count mismatch' as failure
+where (select count(*) from {{ ref('incremental_events') }}) != 2
+
+union all
+
+select 'initial incremental_events missing alpha row' as failure
+where not exists (
+    select 1 from {{ ref('incremental_events') }}
+    where id = 1 and payload = 'alpha' and batch_id = 1
+)
+
+union all
+
+select 'initial incremental_events missing beta row' as failure
+where not exists (
+    select 1 from {{ ref('incremental_events') }}
+    where id = 2 and payload = 'beta' and batch_id = 1
+)
+
+{% elif expected_stage == 'incremental' %}
+
+union all
+
+select 'incremental incremental_events row count mismatch' as failure
+where (select count(*) from {{ ref('incremental_events') }}) != 3
+
+union all
+
+select 'incremental incremental_events missing gamma row' as failure
+where not exists (
+    select 1 from {{ ref('incremental_events') }}
+    where id = 3 and payload = 'gamma' and batch_id = 2
+)
+
+union all
+
+select 'incremental incremental_events should keep initial rows' as failure
+where not exists (
+    select 1 from {{ ref('incremental_events') }}
+    where id = 1 and payload = 'alpha' and batch_id = 1
+)
+
+{% elif expected_stage == 'full_refresh' %}
+
+union all
+
+select 'full-refresh incremental_events row count mismatch' as failure
+where (select count(*) from {{ ref('incremental_events') }}) != 2
+
+union all
+
+select 'full-refresh incremental_events missing reset_alpha row' as failure
+where not exists (
+    select 1 from {{ ref('incremental_events') }}
+    where id = 10 and payload = 'reset_alpha' and batch_id = 3
+)
+
+union all
+
+select 'full-refresh incremental_events missing reset_beta row' as failure
+where not exists (
+    select 1 from {{ ref('incremental_events') }}
+    where id = 11 and payload = 'reset_beta' and batch_id = 3
+)
+
+union all
+
+select 'full-refresh incremental_events should not keep stale incremental rows' as failure
+where exists (
+    select 1 from {{ ref('incremental_events') }}
+    where id in (1, 2, 3)
+)
+
+{% endif %}


### PR DESCRIPTION
## Summary
- add a dedicated dbt CLI e2e fixture for `incremental` materialization
- validate initial full-refresh creation from a source table
- append source data and validate a second `dbt run` only adds the new incremental row
- reset source data and validate `dbt run --full-refresh` rebuilds the target and removes stale incremental rows
- add a CI job that runs the fixture with live RisingWave via `dbt run-operation`, `dbt run`, `dbt test`, and `dbt docs generate`

## Validation
- `git diff --check`
- `dbt parse --profiles-dir <tmp> --project-dir tests/e2e/incremental --no-partial-parse`
- `DBT_RW_INCREMENTAL_EXPECT_STAGE=incremental dbt parse --profiles-dir <tmp> --project-dir tests/e2e/incremental --no-partial-parse`
- `DBT_RW_INCREMENTAL_EXPECT_STAGE=full_refresh dbt parse --profiles-dir <tmp> --project-dir tests/e2e/incremental --no-partial-parse`

Local RisingWave on `localhost:4566` was unavailable, so live execution is covered by CI.