### PR TITLE
test: add model contracts e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,3 +336,53 @@ jobs:
     - name: dbt-doc
       run: dbt docs generate
       working-directory: tests/e2e/incremental
+
+  test-contracts:
+    runs-on: ubuntu-latest
+    services:
+      risingwave:
+        image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        ports:
+          - 4566:4566
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Setup dbt profile
+      run: |
+        mkdir -p $HOME/.dbt && cat >> $HOME/.dbt/profiles.yml <<EOF
+        dbt_risingwave_contracts:
+          outputs:
+            dev:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dev
+              port: 4566
+              schema: public
+          target: dev
+        EOF
+    - name: Install current adapter
+      run: python3 -m pip install .
+    - name: Wait for RisingWave to be ready
+      run: timeout 60 bash -c 'until nc -z 127.0.0.1 4566; do sleep 1; done'
+    - name: dbt-run-contracts
+      run: dbt run --full-refresh --select path:models/positive
+      working-directory: tests/e2e/contracts
+    - name: dbt-test-contracts
+      run: dbt test
+      working-directory: tests/e2e/contracts
+    - name: dbt-run-bad-contract
+      run: |
+        if dbt run --select path:models/negative; then
+          echo "bad contract model unexpectedly succeeded"
+          exit 1
+        fi
+      working-directory: tests/e2e/contracts
+    - name: dbt-doc
+      run: dbt docs generate
+      working-directory: tests/e2e/contracts

--- a/tests/e2e/contracts/dbt_project.yml
+++ b/tests/e2e/contracts/dbt_project.yml
@@ -1,0 +1,8 @@
+name: dbt_risingwave_contracts
+version: "1.0"
+config-version: 2
+
+profile: dbt_risingwave_contracts
+
+model-paths: ["models"]
+test-paths: ["tests"]

--- a/tests/e2e/contracts/models/contracts.yml
+++ b/tests/e2e/contracts/models/contracts.yml
@@ -1,0 +1,22 @@
+version: 2
+
+models:
+  - name: contract_orders
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: integer
+      - name: payload
+        data_type: varchar
+
+  - name: bad_contract_orders
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: id
+        data_type: integer
+      - name: payload
+        data_type: integer

--- a/tests/e2e/contracts/models/negative/bad_contract_orders.sql
+++ b/tests/e2e/contracts/models/negative/bad_contract_orders.sql
@@ -1,0 +1,5 @@
+{{ config(materialized='table', tags=['contract_negative']) }}
+
+select
+    cast(1 as integer) as id,
+    cast('not_an_integer' as varchar) as payload

--- a/tests/e2e/contracts/models/positive/contract_orders.sql
+++ b/tests/e2e/contracts/models/positive/contract_orders.sql
@@ -1,0 +1,9 @@
+{{ config(materialized='table') }}
+
+select
+    cast(1 as integer) as id,
+    cast('alpha' as varchar) as payload
+union all
+select
+    cast(2 as integer) as id,
+    cast('beta' as varchar) as payload

--- a/tests/e2e/contracts/tests/assert_contract_orders.sql
+++ b/tests/e2e/contracts/tests/assert_contract_orders.sql
@@ -1,0 +1,32 @@
+select 'contract_orders must be a table' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'contract_orders'
+      and rw_relations.relation_type = 'table'
+)
+
+union all
+
+select 'contract_orders row count mismatch' as failure
+where (select count(*) from {{ ref('contract_orders') }}) != 2
+
+union all
+
+select 'contract_orders missing alpha row' as failure
+where not exists (
+    select 1
+    from {{ ref('contract_orders') }}
+    where id = 1 and payload = 'alpha'
+)
+
+union all
+
+select 'contract_orders missing beta row' as failure
+where not exists (
+    select 1
+    from {{ ref('contract_orders') }}
+    where id = 2 and payload = 'beta'
+)


### PR DESCRIPTION
## Summary
- add a dedicated `tests/e2e/contracts` dbt project for model contract coverage
- cover a successful contract-enforced table build plus a negative schema-mismatch path
- add a `test-contracts` CI job that runs dbt CLI e2e against live RisingWave

## Validation
- local: `dbt parse --project-dir tests/e2e/contracts`
- local: `dbt run --full-refresh --select path:models/positive`
- local: `dbt test`
- local: negative `dbt run --select path:models/negative` fails on contract mismatch
- local: `dbt docs generate`

This is dbt CLI e2e coverage, not an adapter unit test. Live validation depends on CI as well.