### PR TITLE
test: add store_failures e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,3 +386,50 @@ jobs:
     - name: dbt-doc
       run: dbt docs generate
       working-directory: tests/e2e/contracts
+
+  test-store-failures:
+    runs-on: ubuntu-latest
+    services:
+      risingwave:
+        image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        ports:
+          - 4566:4566
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Setup dbt profile
+      run: |
+        mkdir -p $HOME/.dbt && cat >> $HOME/.dbt/profiles.yml <<EOF
+        dbt_risingwave_store_failures:
+          outputs:
+            dev:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dev
+              port: 4566
+              schema: public
+          target: dev
+        EOF
+    - name: Install current adapter
+      run: python3 -m pip install .
+    - name: Wait for RisingWave to be ready
+      run: timeout 60 bash -c 'until nc -z 127.0.0.1 4566; do sleep 1; done'
+    - name: dbt-run
+      run: dbt run --full-refresh
+      working-directory: tests/e2e/store_failures
+    - name: dbt-test-store-failures
+      run: |
+        if dbt test --select store_failures_persisted; then
+          echo "store_failures_persisted unexpectedly succeeded"
+          exit 1
+        fi
+      working-directory: tests/e2e/store_failures
+    - name: assert-store-failures
+      run: dbt run-operation assert_store_failures_results
+      working-directory: tests/e2e/store_failures

--- a/tests/e2e/store_failures/dbt_project.yml
+++ b/tests/e2e/store_failures/dbt_project.yml
@@ -1,0 +1,9 @@
+name: dbt_risingwave_store_failures
+version: "1.0"
+config-version: 2
+
+profile: dbt_risingwave_store_failures
+
+model-paths: ["models"]
+macro-paths: ["macros"]
+test-paths: ["tests"]

--- a/tests/e2e/store_failures/macros/assert_store_failures_results.sql
+++ b/tests/e2e/store_failures/macros/assert_store_failures_results.sql
@@ -1,0 +1,56 @@
+{% macro store_failures_results_relation() %}
+  {% set audit_schema = target.schema ~ '_dbt_test__audit' %}
+  {{ return(api.Relation.create(
+      identifier='store_failures_results',
+      schema=audit_schema,
+      database=target.database,
+      type='materialized_view'
+  )) }}
+{% endmacro %}
+
+{% macro assert_store_failures_results() %}
+  {% set relation = store_failures_results_relation() %}
+
+  {% set relation_sql %}
+    select rw_relations.relation_type
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ relation.schema }}'
+      and rw_relations.name = '{{ relation.identifier }}'
+  {% endset %}
+
+  {% set relation_results = run_query(relation_sql) %}
+
+  {% if execute %}
+    {% if relation_results is none or relation_results.rows | length != 1 %}
+      {{ exceptions.raise_compiler_error(relation.identifier ~ ' relation was not created') }}
+    {% endif %}
+
+    {% set relation_type = relation_results.rows[0][0] %}
+    {% if relation_type != 'materialized view' %}
+      {{ exceptions.raise_compiler_error(relation.identifier ~ ' relation has wrong type: ' ~ relation_type) }}
+    {% endif %}
+
+    {% set row_count_sql %}
+      select count(*) as row_count
+      from {{ relation }}
+    {% endset %}
+
+    {% set row_count_results = run_query(row_count_sql) %}
+    {% set row_count = row_count_results.rows[0][0] %}
+    {% if row_count != 1 %}
+      {{ exceptions.raise_compiler_error(relation.identifier ~ ' row count mismatch: ' ~ row_count) }}
+    {% endif %}
+
+    {% set expected_row_sql %}
+      select 1
+      from {{ relation }}
+      where id = 2 and status = 'bad'
+    {% endset %}
+
+    {% set expected_row_results = run_query(expected_row_sql) %}
+    {% if expected_row_results is none or expected_row_results.rows | length != 1 %}
+      {{ exceptions.raise_compiler_error(relation.identifier ~ ' missing expected failure row') }}
+    {% endif %}
+  {% endif %}
+{% endmacro %}

--- a/tests/e2e/store_failures/models/store_failures_input.sql
+++ b/tests/e2e/store_failures/models/store_failures_input.sql
@@ -1,0 +1,9 @@
+{{ config(materialized='table') }}
+
+select
+    cast(1 as integer) as id,
+    cast('ok' as varchar) as status
+union all
+select
+    cast(2 as integer) as id,
+    cast('bad' as varchar) as status

--- a/tests/e2e/store_failures/tests/store_failures_persisted.sql
+++ b/tests/e2e/store_failures/tests/store_failures_persisted.sql
@@ -1,0 +1,13 @@
+{{
+  config(
+    store_failures=true,
+    store_failures_as='materialized_view',
+    alias='store_failures_results'
+  )
+}}
+
+select
+    id,
+    status
+from {{ ref('store_failures_input') }}
+where status = 'bad'


### PR DESCRIPTION
## Summary
- add a dedicated `tests/e2e/store_failures` dbt project for `store_failures_as` coverage
- cover a singular data test configured with `store_failures_as: materialized_view` that intentionally fails
- add a `test-store-failures` CI job that allows the test failure, then verifies the persisted failure relation in RisingWave

## Validation
- local: `dbt parse --project-dir tests/e2e/store_failures`
- local: `dbt run --project-dir tests/e2e/store_failures --full-refresh`
- local: `dbt test --project-dir tests/e2e/store_failures --select store_failures_persisted` fails as expected
- local: `dbt run-operation --project-dir tests/e2e/store_failures assert_store_failures_results`

Notes:
- dbt stores persisted test failures in the audit schema (`<target_schema>_dbt_test__audit`), so the verification macro checks that path explicitly.
- This PR intentionally stays scoped to data-test failure persistence only; it does not add functions, sources, zero-downtime, or other materialization coverage.