### PR TITLE
test: add index configuration e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,3 +433,62 @@ jobs:
     - name: assert-store-failures
       run: dbt run-operation assert_store_failures_results
       working-directory: tests/e2e/store_failures
+
+  test-indexes:
+    runs-on: ubuntu-latest
+    services:
+      risingwave:
+        image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        ports:
+          - 4566:4566
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Setup dbt profile
+      run: |
+        mkdir -p $HOME/.dbt && cat >> $HOME/.dbt/profiles.yml <<EOF
+        dbt_risingwave_indexes:
+          outputs:
+            dev:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dev
+              port: 4566
+              schema: public
+          target: dev
+        EOF
+    - name: Install current adapter
+      run: python3 -m pip install .
+    - name: Wait for RisingWave to be ready
+      run: timeout 60 bash -c 'until nc -z 127.0.0.1 4566; do sleep 1; done'
+    - name: dbt-run-initial-index
+      run: dbt run --full-refresh
+      working-directory: tests/e2e/indexes
+      env:
+        DBT_RW_INDEX_STAGE: initial
+    - name: dbt-test-initial-index
+      run: dbt test
+      working-directory: tests/e2e/indexes
+      env:
+        DBT_RW_INDEX_EXPECT_STAGE: initial
+    - name: dbt-run-apply-index-change
+      run: dbt run
+      working-directory: tests/e2e/indexes
+      env:
+        DBT_RW_INDEX_STAGE: changed
+    - name: dbt-test-changed-index
+      run: dbt test
+      working-directory: tests/e2e/indexes
+      env:
+        DBT_RW_INDEX_EXPECT_STAGE: changed
+    - name: dbt-doc
+      run: dbt docs generate
+      working-directory: tests/e2e/indexes
+      env:
+        DBT_RW_INDEX_STAGE: changed

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -139,7 +139,7 @@
 {% endmacro %}
 
 {% macro risingwave__get_create_index_sql(relation, index_dict) -%}
-  {%- set index_config = adapter.parse_index(index_dict) -%}
+  {%- set index_config = adapter.parse_index({"columns": index_dict.get("columns", [])}) -%}
   {%- set comma_separated_columns = ", ".join(index_config.columns) -%}
   {%- set index_name = risingwave__get_index_name(relation.identifier, index_config.columns) -%}
 

--- a/tests/e2e/indexes/dbt_project.yml
+++ b/tests/e2e/indexes/dbt_project.yml
@@ -1,0 +1,8 @@
+name: dbt_risingwave_indexes
+version: "1.0"
+config-version: 2
+
+profile: dbt_risingwave_indexes
+
+model-paths: ["models"]
+test-paths: ["tests"]

--- a/tests/e2e/indexes/models/indexed_events_mv.sql
+++ b/tests/e2e/indexes/models/indexed_events_mv.sql
@@ -1,0 +1,34 @@
+{% set index_stage = env_var('DBT_RW_INDEX_STAGE', 'initial') %}
+
+{% if index_stage == 'initial' %}
+  {% set index_config = {
+      'columns': ['user_id'],
+      'include': ['event_type'],
+      'distributed_by': ['user_id']
+  } %}
+{% elif index_stage == 'changed' %}
+  {% set index_config = {
+      'columns': ['event_type'],
+      'include': ['user_id'],
+      'distributed_by': ['event_type']
+  } %}
+{% else %}
+  {{ exceptions.raise_compiler_error("Invalid DBT_RW_INDEX_STAGE: " ~ index_stage) }}
+{% endif %}
+
+{{ config(
+    materialized='materialized_view',
+    indexes=[index_config],
+    on_configuration_change='apply',
+    background_ddl=true
+) }}
+
+select
+    cast(1 as int) as event_id,
+    cast(101 as int) as user_id,
+    cast('click' as varchar) as event_type
+union all
+select
+    cast(2 as int) as event_id,
+    cast(202 as int) as user_id,
+    cast('purchase' as varchar) as event_type

--- a/tests/e2e/indexes/tests/assert_index_configuration.sql
+++ b/tests/e2e/indexes/tests/assert_index_configuration.sql
@@ -1,0 +1,56 @@
+{% set expected_stage = env_var('DBT_RW_INDEX_EXPECT_STAGE', 'initial') %}
+
+{% if expected_stage == 'initial' %}
+  {% set expected_index = '__dbt_index_indexed_events_mv_user_id' %}
+  {% set stale_index = '__dbt_index_indexed_events_mv_event_type' %}
+{% elif expected_stage == 'changed' %}
+  {% set expected_index = '__dbt_index_indexed_events_mv_event_type' %}
+  {% set stale_index = '__dbt_index_indexed_events_mv_user_id' %}
+{% else %}
+  {{ exceptions.raise_compiler_error("Invalid DBT_RW_INDEX_EXPECT_STAGE: " ~ expected_stage) }}
+{% endif %}
+
+select 'indexed_events_mv must be a materialized view' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'indexed_events_mv'
+      and rw_relations.relation_type = 'materialized view'
+)
+
+union all
+
+select 'indexed_events_mv has unexpected row count' as failure
+where (select count(*) from {{ ref('indexed_events_mv') }}) != 2
+
+union all
+
+select '{{ expected_index }} must exist' as failure
+where not exists (
+    select 1
+    from pg_index ix
+    join pg_class i on i.oid = ix.indexrelid
+    join pg_class t on t.oid = ix.indrelid
+    join pg_namespace n on n.oid = t.relnamespace
+    where n.nspname = '{{ target.schema }}'
+      and t.relname = 'indexed_events_mv'
+      and i.relname = '{{ expected_index }}'
+      and ix.indisprimary = false
+)
+
+union all
+
+select '{{ stale_index }} should not exist' as failure
+where exists (
+    select 1
+    from pg_index ix
+    join pg_class i on i.oid = ix.indexrelid
+    join pg_class t on t.oid = ix.indrelid
+    join pg_namespace n on n.oid = t.relnamespace
+    where n.nspname = '{{ target.schema }}'
+      and t.relname = 'indexed_events_mv'
+      and i.relname = '{{ stale_index }}'
+      and ix.indisprimary = false
+)


### PR DESCRIPTION
## Summary
- add an isolated `tests/e2e/indexes` fixture for RisingWave index config coverage
- verify initial index creation on a materialized view
- verify `on_configuration_change='apply'` drops the stale index and creates the changed index
- fix RisingWave index recreation so dbt generic `parse_index` only receives generic index fields while RisingWave-specific `include` / `distributed_by` are still rendered by the adapter macro

## Validation
- `git diff --check`
- `dbt parse` in `tests/e2e/indexes`
- live RisingWave on localhost:4566:
  - `dbt run --full-refresh`
  - `dbt test`
  - `DBT_RW_INDEX_STAGE=changed dbt run`
  - `DBT_RW_INDEX_EXPECT_STAGE=changed dbt test`
  - `DBT_RW_INDEX_STAGE=changed dbt docs generate`