### PR TITLE
test: add zero downtime e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,7 +537,7 @@ jobs:
       env:
         DBT_RW_ZERO_DOWNTIME_EXPECT_STAGE: initial
     - name: dbt-run-zero-downtime-swap
-      run: dbt run --vars '{zero_downtime: true}'
+      run: "dbt run --vars '{zero_downtime: true}'"
       working-directory: tests/e2e/zero_downtime
       env:
         DBT_RW_ZERO_DOWNTIME_STAGE: changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,3 +492,62 @@ jobs:
       working-directory: tests/e2e/indexes
       env:
         DBT_RW_INDEX_STAGE: changed
+
+  test-zero-downtime:
+    runs-on: ubuntu-latest
+    services:
+      risingwave:
+        image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        ports:
+          - 4566:4566
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Setup dbt profile
+      run: |
+        mkdir -p $HOME/.dbt && cat >> $HOME/.dbt/profiles.yml <<EOF
+        dbt_risingwave_zero_downtime:
+          outputs:
+            dev:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dev
+              port: 4566
+              schema: public
+          target: dev
+        EOF
+    - name: Install current adapter
+      run: python3 -m pip install .
+    - name: Wait for RisingWave to be ready
+      run: timeout 60 bash -c 'until nc -z 127.0.0.1 4566; do sleep 1; done'
+    - name: dbt-run-initial
+      run: dbt run --full-refresh
+      working-directory: tests/e2e/zero_downtime
+      env:
+        DBT_RW_ZERO_DOWNTIME_STAGE: initial
+    - name: dbt-test-initial
+      run: dbt test
+      working-directory: tests/e2e/zero_downtime
+      env:
+        DBT_RW_ZERO_DOWNTIME_EXPECT_STAGE: initial
+    - name: dbt-run-zero-downtime-swap
+      run: dbt run --vars '{zero_downtime: true}'
+      working-directory: tests/e2e/zero_downtime
+      env:
+        DBT_RW_ZERO_DOWNTIME_STAGE: changed
+    - name: dbt-test-zero-downtime-swap
+      run: dbt test
+      working-directory: tests/e2e/zero_downtime
+      env:
+        DBT_RW_ZERO_DOWNTIME_EXPECT_STAGE: changed
+    - name: dbt-doc
+      run: dbt docs generate
+      working-directory: tests/e2e/zero_downtime
+      env:
+        DBT_RW_ZERO_DOWNTIME_STAGE: changed

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -76,6 +76,21 @@
   {{ return(load_result('list_relations_without_caching').table) }}
 {% endmacro %}
 
+{% macro risingwave__get_relation_without_caching(relation) %}
+  {% set catalog_relations = risingwave__list_relations_without_caching(relation) %}
+  {% for catalog_relation in catalog_relations %}
+    {% if catalog_relation[1] == relation.identifier %}
+      {{ return(api.Relation.create(
+          database=catalog_relation[0],
+          identifier=catalog_relation[1],
+          schema=catalog_relation[2],
+          type=catalog_relation[3]
+      )) }}
+    {% endif %}
+  {% endfor %}
+  {{ return(none) }}
+{% endmacro %}
+
 {% macro risingwave__create_schema(relation) -%}
   {% if relation.database -%}
     {{ adapter.verify_database(relation.database) }}

--- a/dbt/include/risingwave/macros/materializations/materialized_view.sql
+++ b/dbt/include/risingwave/macros/materializations/materialized_view.sql
@@ -1,13 +1,11 @@
 {% materialization materialized_view, adapter='risingwave' %}
   {%- set identifier = model['alias'] -%}
   {%- set full_refresh_mode = should_full_refresh() -%}
-  {%- set old_relation = adapter.get_relation(identifier=identifier,
-                                              schema=schema,
-                                              database=database) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
                                                 database=database,
                                                 type='materialized_view') -%}
+  {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
 
   {%- set grant_config = config.get('grants') -%}
   {# Check both model config AND command line flag for zero downtime #}

--- a/dbt/include/risingwave/macros/materializations/view.sql
+++ b/dbt/include/risingwave/macros/materializations/view.sql
@@ -1,13 +1,11 @@
 {% materialization view, adapter='risingwave' %}
   {%- set identifier = model['alias'] -%}
   {%- set full_refresh_mode = should_full_refresh() -%}
-  {%- set old_relation = adapter.get_relation(identifier=identifier,
-                                              schema=schema,
-                                              database=database) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
                                                 database=database,
                                                 type='view') -%}
+  {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
 
   {# Check both model config AND command line flag for zero downtime #}
   {%- set zero_downtime_config = config.get('zero_downtime', {}) -%}

--- a/tests/e2e/zero_downtime/dbt_project.yml
+++ b/tests/e2e/zero_downtime/dbt_project.yml
@@ -1,0 +1,8 @@
+name: dbt_risingwave_zero_downtime
+version: "1.0"
+config-version: 2
+
+profile: dbt_risingwave_zero_downtime
+
+model-paths: ["models"]
+test-paths: ["tests"]

--- a/tests/e2e/zero_downtime/models/zd_base_view.sql
+++ b/tests/e2e/zero_downtime/models/zd_base_view.sql
@@ -1,0 +1,21 @@
+{% set stage = env_var('DBT_RW_ZERO_DOWNTIME_STAGE', 'initial') %}
+
+{% if stage not in ['initial', 'changed'] %}
+  {{ exceptions.raise_compiler_error("Invalid DBT_RW_ZERO_DOWNTIME_STAGE: " ~ stage) }}
+{% endif %}
+
+{{ config(
+    materialized='view',
+    zero_downtime={
+      'enabled': true,
+      'immediate_cleanup': true
+    }
+) }}
+
+select
+    cast(1 as int) as id,
+    cast('{{ stage }}_view_alpha' as varchar) as payload
+union all
+select
+    cast(2 as int) as id,
+    cast('{{ stage }}_view_beta' as varchar) as payload

--- a/tests/e2e/zero_downtime/models/zd_chain_final_mv.sql
+++ b/tests/e2e/zero_downtime/models/zd_chain_final_mv.sql
@@ -1,0 +1,14 @@
+{{ config(
+    materialized='materialized_view',
+    background_ddl=true,
+    zero_downtime={
+      'enabled': true,
+      'immediate_cleanup': true
+    }
+) }}
+
+select
+    id,
+    derived_amount + 1 as final_amount,
+    transform_version
+from {{ ref('zd_chain_middle_mv') }}

--- a/tests/e2e/zero_downtime/models/zd_chain_middle_mv.sql
+++ b/tests/e2e/zero_downtime/models/zd_chain_middle_mv.sql
@@ -1,0 +1,24 @@
+{% set stage = env_var('DBT_RW_ZERO_DOWNTIME_STAGE', 'initial') %}
+
+{% if stage not in ['initial', 'changed'] %}
+  {{ exceptions.raise_compiler_error("Invalid DBT_RW_ZERO_DOWNTIME_STAGE: " ~ stage) }}
+{% endif %}
+
+{{ config(
+    materialized='materialized_view',
+    background_ddl=true,
+    zero_downtime={
+      'enabled': true,
+      'immediate_cleanup': true
+    }
+) }}
+
+select
+    id,
+    {% if stage == 'initial' %}
+    amount * 10
+    {% else %}
+    amount * 100 + 7
+    {% endif %} as derived_amount,
+    cast('{{ stage }}' as varchar) as transform_version
+from {{ ref('zd_chain_source_mv') }}

--- a/tests/e2e/zero_downtime/models/zd_chain_source_mv.sql
+++ b/tests/e2e/zero_downtime/models/zd_chain_source_mv.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='materialized_view',
+    background_ddl=true
+) }}
+
+select
+    cast(1 as int) as id,
+    cast(10 as int) as amount
+union all
+select
+    cast(2 as int) as id,
+    cast(20 as int) as amount

--- a/tests/e2e/zero_downtime/models/zd_events_mv.sql
+++ b/tests/e2e/zero_downtime/models/zd_events_mv.sql
@@ -1,0 +1,24 @@
+{% set stage = env_var('DBT_RW_ZERO_DOWNTIME_STAGE', 'initial') %}
+
+{% if stage not in ['initial', 'changed'] %}
+  {{ exceptions.raise_compiler_error("Invalid DBT_RW_ZERO_DOWNTIME_STAGE: " ~ stage) }}
+{% endif %}
+
+{{ config(
+    materialized='materialized_view',
+    background_ddl=true,
+    zero_downtime={
+      'enabled': true,
+      'immediate_cleanup': true
+    }
+) }}
+
+select
+    cast(1 as int) as id,
+    cast('{{ stage }}_mv_alpha' as varchar) as payload,
+    cast('{{ stage }}' as varchar) as deploy_stage
+union all
+select
+    cast(2 as int) as id,
+    cast('{{ stage }}_mv_beta' as varchar) as payload,
+    cast('{{ stage }}' as varchar) as deploy_stage

--- a/tests/e2e/zero_downtime/tests/assert_zero_downtime_materializations.sql
+++ b/tests/e2e/zero_downtime/tests/assert_zero_downtime_materializations.sql
@@ -1,0 +1,86 @@
+{% set expected_stage = env_var('DBT_RW_ZERO_DOWNTIME_EXPECT_STAGE', 'initial') %}
+
+{% if expected_stage not in ['initial', 'changed'] %}
+  {{ exceptions.raise_compiler_error("Invalid DBT_RW_ZERO_DOWNTIME_EXPECT_STAGE: " ~ expected_stage) }}
+{% endif %}
+
+select 'zd_base_view must be a view' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'zd_base_view'
+      and rw_relations.relation_type = 'view'
+)
+
+union all
+
+select 'zd_events_mv must be a materialized view' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'zd_events_mv'
+      and rw_relations.relation_type = 'materialized view'
+)
+
+union all
+
+select 'zero-downtime temp relations should be cleaned up' as failure
+where exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name like '%_dbt_zero_down_tmp_%'
+)
+
+union all
+
+select 'zd_base_view has unexpected row count' as failure
+where (select count(*) from {{ ref('zd_base_view') }}) != 2
+
+union all
+
+select 'zd_base_view missing alpha row for expected stage' as failure
+where not exists (
+    select 1
+    from {{ ref('zd_base_view') }}
+    where id = 1 and payload = '{{ expected_stage }}_view_alpha'
+)
+
+union all
+
+select 'zd_base_view still exposes stale rows after swap' as failure
+where exists (
+    select 1
+    from {{ ref('zd_base_view') }}
+    where payload not like '{{ expected_stage }}_%'
+)
+
+union all
+
+select 'zd_events_mv has unexpected row count' as failure
+where (select count(*) from {{ ref('zd_events_mv') }}) != 2
+
+union all
+
+select 'zd_events_mv missing alpha row for expected stage' as failure
+where not exists (
+    select 1
+    from {{ ref('zd_events_mv') }}
+    where id = 1
+      and payload = '{{ expected_stage }}_mv_alpha'
+      and deploy_stage = '{{ expected_stage }}'
+)
+
+union all
+
+select 'zd_events_mv still exposes stale rows after swap' as failure
+where exists (
+    select 1
+    from {{ ref('zd_events_mv') }}
+    where deploy_stage != '{{ expected_stage }}'
+)

--- a/tests/e2e/zero_downtime/tests/assert_zero_downtime_materializations.sql
+++ b/tests/e2e/zero_downtime/tests/assert_zero_downtime_materializations.sql
@@ -28,6 +28,42 @@ where not exists (
 
 union all
 
+select 'zd_chain_source_mv must be a materialized view' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'zd_chain_source_mv'
+      and rw_relations.relation_type = 'materialized view'
+)
+
+union all
+
+select 'zd_chain_middle_mv must be a materialized view after zero-downtime swap' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'zd_chain_middle_mv'
+      and rw_relations.relation_type = 'materialized view'
+)
+
+union all
+
+select 'zd_chain_final_mv must be a materialized view after upstream zero-downtime swap' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'zd_chain_final_mv'
+      and rw_relations.relation_type = 'materialized view'
+)
+
+union all
+
 select 'zero-downtime temp relations should be cleaned up' as failure
 where exists (
     select 1
@@ -83,4 +119,54 @@ where exists (
     select 1
     from {{ ref('zd_events_mv') }}
     where deploy_stage != '{{ expected_stage }}'
+)
+
+union all
+
+select 'zd_chain_middle_mv has unexpected row count' as failure
+where (select count(*) from {{ ref('zd_chain_middle_mv') }}) != 2
+
+union all
+
+select 'zd_chain_middle_mv did not apply the expected intermediate definition' as failure
+where not exists (
+    select 1
+    from {{ ref('zd_chain_middle_mv') }}
+    where id = 1
+      and derived_amount = {% if expected_stage == 'initial' %}100{% else %}1007{% endif %}
+      and transform_version = '{{ expected_stage }}'
+)
+
+union all
+
+select 'zd_chain_middle_mv still exposes stale intermediate definition rows' as failure
+where exists (
+    select 1
+    from {{ ref('zd_chain_middle_mv') }}
+    where transform_version != '{{ expected_stage }}'
+)
+
+union all
+
+select 'zd_chain_final_mv has unexpected row count' as failure
+where (select count(*) from {{ ref('zd_chain_final_mv') }}) != 2
+
+union all
+
+select 'zd_chain_final_mv did not rebuild against changed intermediate definition' as failure
+where not exists (
+    select 1
+    from {{ ref('zd_chain_final_mv') }}
+    where id = 1
+      and final_amount = {% if expected_stage == 'initial' %}101{% else %}1008{% endif %}
+      and transform_version = '{{ expected_stage }}'
+)
+
+union all
+
+select 'zd_chain_final_mv still exposes rows from stale intermediate definition' as failure
+where exists (
+    select 1
+    from {{ ref('zd_chain_final_mv') }}
+    where transform_version != '{{ expected_stage }}'
 )


### PR DESCRIPTION
## Summary
- add an isolated `tests/e2e/zero_downtime` fixture and CI job
- cover zero-downtime reruns for both standalone `view` and `materialized_view`
- add a chained MV case: `zd_chain_source_mv -> zd_chain_middle_mv -> zd_chain_final_mv`
- make `zd_chain_middle_mv` change its SQL definition between the initial run and the zero-downtime rerun, then verify `zd_chain_final_mv` rebuilds against the changed intermediate definition
- fix stale relation detection for view/MV materializations by refreshing relation existence from RisingWave catalog instead of trusting dbt's cache; this matters when SWAP cleanup cascades a downstream relation before dbt executes that downstream model
- verify temporary `_dbt_zero_down_tmp_` relations are cleaned up after the swap

## Validation
- `git diff --check HEAD~1..HEAD`
- live RisingWave on localhost:4566:
  - `dbt parse`
  - `DBT_RW_ZERO_DOWNTIME_STAGE=initial dbt run --full-refresh`
  - `DBT_RW_ZERO_DOWNTIME_EXPECT_STAGE=initial dbt test`
  - `DBT_RW_ZERO_DOWNTIME_STAGE=changed dbt run --vars '{zero_downtime: true}'`
  - `DBT_RW_ZERO_DOWNTIME_EXPECT_STAGE=changed dbt test`
  - `DBT_RW_ZERO_DOWNTIME_STAGE=changed dbt docs generate`