### PR TITLE
test: add source and connection e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,6 +641,7 @@ jobs:
               dbname: dev
               port: 4566
               schema: dbt_e2e_grants_docs_schema
+              schema: dbt_e2e_grants_docs_schema
           target: dev
         EOF
     - name: Install current adapter
@@ -665,3 +666,53 @@ jobs:
     - name: dbt-doc
       run: dbt docs generate
       working-directory: tests/e2e/grants_docs_schema
+
+  test-source-connection:
+    runs-on: ubuntu-latest
+    env:
+      DBT_RW_SCHEMA_REGISTRY_URL: http://host.docker.internal:18081
+    services:
+      risingwave:
+        image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        ports:
+          - 4566:4566
+        options: >-
+          --add-host=host.docker.internal:host-gateway
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Setup dbt profile
+      run: |
+        mkdir -p $HOME/.dbt && cat >> $HOME/.dbt/profiles.yml <<EOF
+        dbt_risingwave_source_connection:
+          outputs:
+            dev:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dev
+              port: 4566
+              schema: public
+          target: dev
+        EOF
+    - name: Install current adapter
+      run: python3 -m pip install .
+    - name: Wait for RisingWave to be ready
+      run: timeout 60 bash -c 'until nc -z 127.0.0.1 4566; do sleep 1; done'
+    - name: dbt-source-connection-e2e
+      run: |
+        python3 scripts/mock_schema_registry.py > /tmp/mock_schema_registry.log 2>&1 &
+        mock_schema_registry_pid=$!
+        trap 'kill $mock_schema_registry_pid >/dev/null 2>&1 || true' EXIT
+        timeout 30 bash -c 'until nc -z 127.0.0.1 18081; do sleep 1; done'
+        dbt run --full-refresh
+        dbt test
+        dbt run
+        dbt test
+        dbt docs generate
+      working-directory: tests/e2e/source_connection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,11 +616,15 @@ jobs:
 
   test-grants-docs-schema:
     runs-on: ubuntu-latest
+    env:
+      DBT_RW_SCHEMA_REGISTRY_URL: http://host.docker.internal:18081
     services:
       risingwave:
         image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
         ports:
           - 4566:4566
+        options: >-
+          --add-host=host.docker.internal:host-gateway
 
     steps:
     - uses: actions/checkout@v3

--- a/tests/e2e/source_connection/dbt_project.yml
+++ b/tests/e2e/source_connection/dbt_project.yml
@@ -1,0 +1,8 @@
+name: dbt_risingwave_source_connection
+version: "1.0"
+config-version: 2
+
+profile: dbt_risingwave_source_connection
+
+model-paths: ["models"]
+test-paths: ["tests"]

--- a/tests/e2e/source_connection/models/datagen_source.sql
+++ b/tests/e2e/source_connection/models/datagen_source.sql
@@ -1,0 +1,16 @@
+{{ config(materialized='source') }}
+
+create source {{ this }} (
+    id integer,
+    payload varchar
+)
+with (
+    connector = 'datagen',
+    fields.id.kind = 'sequence',
+    fields.id.start = '1',
+    fields.id.end = '100',
+    fields.payload.kind = 'random',
+    fields.payload.length = '8',
+    fields.payload.seed = '7',
+    datagen.rows.per.second = '5'
+)

--- a/tests/e2e/source_connection/models/schema_registry_connection.sql
+++ b/tests/e2e/source_connection/models/schema_registry_connection.sql
@@ -1,0 +1,6 @@
+{{ config(materialized='connection') }}
+
+create connection {{ this.identifier }} with (
+    type = 'schema_registry',
+    schema.registry = 'http://127.0.0.1:18081'
+)

--- a/tests/e2e/source_connection/models/schema_registry_connection.sql
+++ b/tests/e2e/source_connection/models/schema_registry_connection.sql
@@ -2,5 +2,5 @@
 
 create connection {{ this.identifier }} with (
     type = 'schema_registry',
-    schema.registry = 'http://127.0.0.1:18081'
+    schema.registry = '{{ env_var("DBT_RW_SCHEMA_REGISTRY_URL", "http://127.0.0.1:18081") }}'
 )

--- a/tests/e2e/source_connection/scripts/mock_schema_registry.py
+++ b/tests/e2e/source_connection/scripts/mock_schema_registry.py
@@ -1,15 +1,29 @@
-from http.server import BaseHTTPRequestHandler, HTTPServer
+import socketserver
 
 
-class MockSchemaRegistryHandler(BaseHTTPRequestHandler):
-    def do_GET(self):
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.end_headers()
-        self.wfile.write(b'{"compatibilityLevel":"BACKWARD"}')
+RESPONSE_BODY = b'{"compatibilityLevel":"BACKWARD"}'
+RESPONSE = (
+    b"HTTP/1.1 200 OK\r\n"
+    b"Content-Type: application/json\r\n"
+    + f"Content-Length: {len(RESPONSE_BODY)}\r\n".encode()
+    + b"Connection: close\r\n\r\n"
+    + RESPONSE_BODY
+)
 
-    def log_message(self, fmt, *args):
-        return
+
+class MockSchemaRegistryHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        try:
+            request_bytes = self.request.recv(4096)
+            if not request_bytes:
+                return
+            self.request.sendall(RESPONSE)
+        except OSError:
+            return
 
 
-HTTPServer(("127.0.0.1", 18081), MockSchemaRegistryHandler).serve_forever()
+class ReusableTCPServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+
+ReusableTCPServer(("0.0.0.0", 18081), MockSchemaRegistryHandler).serve_forever()

--- a/tests/e2e/source_connection/scripts/mock_schema_registry.py
+++ b/tests/e2e/source_connection/scripts/mock_schema_registry.py
@@ -1,0 +1,15 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class MockSchemaRegistryHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"compatibilityLevel":"BACKWARD"}')
+
+    def log_message(self, fmt, *args):
+        return
+
+
+HTTPServer(("127.0.0.1", 18081), MockSchemaRegistryHandler).serve_forever()

--- a/tests/e2e/source_connection/tests/assert_source_connection_materializations.sql
+++ b/tests/e2e/source_connection/tests/assert_source_connection_materializations.sql
@@ -1,0 +1,27 @@
+select 'datagen_source must be a source' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'datagen_source'
+      and rw_relations.relation_type = 'source'
+)
+
+union all
+
+select 'schema_registry_connection must exist' as failure
+where not exists (
+    select 1
+    from rw_catalog.rw_connections
+    where name = 'schema_registry_connection'
+)
+
+union all
+
+select 'schema_registry_connection should be unique' as failure
+where (
+    select count(*)
+    from rw_catalog.rw_connections
+    where name = 'schema_registry_connection'
+) != 1


### PR DESCRIPTION
## Summary
- add a dedicated `tests/e2e/source_connection` dbt project for `source` and `connection` materializations
- cover datagen source creation plus schema-registry connection creation, existing-object no-op, and docs generation
- add a `test-source-connection` CI job with a tiny mock schema registry so connection creation is self-contained

## Validation
- local: `dbt parse --project-dir tests/e2e/source_connection`
- local: `dbt run --project-dir tests/e2e/source_connection --full-refresh`
- local: `dbt test --project-dir tests/e2e/source_connection`
- local: second `dbt run` / `dbt test` validates existing-object no-op
- local: `dbt docs generate --project-dir tests/e2e/source_connection`

Notes:
- The connection fixture uses a local mock schema registry that serves `/config` with a minimal `compatibilityLevel` response, because RisingWave validates schema-registry connections at creation time.
- This PR intentionally stays scoped to `source` / `connection` materializations only.