### PR TITLE
test: add grants docs schema e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,3 +613,55 @@ jobs:
     - name: dbt-doc
       run: dbt docs generate
       working-directory: tests/e2e/functions
+
+  test-grants-docs-schema:
+    runs-on: ubuntu-latest
+    services:
+      risingwave:
+        image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        ports:
+          - 4566:4566
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Setup dbt profile
+      run: |
+        mkdir -p $HOME/.dbt && cat >> $HOME/.dbt/profiles.yml <<EOF
+        dbt_risingwave_grants_docs_schema:
+          outputs:
+            dev:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dev
+              port: 4566
+              schema: dbt_e2e_grants_docs_schema
+          target: dev
+        EOF
+    - name: Install current adapter
+      run: python3 -m pip install .
+    - name: Wait for RisingWave to be ready
+      run: timeout 60 bash -c 'until nc -z 127.0.0.1 4566; do sleep 1; done'
+    - name: prepare-roles-and-schema
+      run: dbt run-operation prepare_grants_docs_schema
+      working-directory: tests/e2e/grants_docs_schema
+    - name: dbt-run
+      run: dbt run --full-refresh
+      working-directory: tests/e2e/grants_docs_schema
+    - name: dbt-test
+      run: dbt test
+      working-directory: tests/e2e/grants_docs_schema
+    - name: dbt-run-existing-relations
+      run: dbt run
+      working-directory: tests/e2e/grants_docs_schema
+    - name: dbt-test-existing-relations
+      run: dbt test
+      working-directory: tests/e2e/grants_docs_schema
+    - name: dbt-doc
+      run: dbt docs generate
+      working-directory: tests/e2e/grants_docs_schema

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -112,6 +112,16 @@
   {%- endcall -%}
 {% endmacro %}
 
+{% macro risingwave__ensure_schema_authorization(relation) -%}
+  {%- set configured_owner = config.get("schema_authorization", none) -%}
+  {%- if configured_owner is not none and configured_owner | trim != "" -%}
+    {%- call statement('alter_schema_owner') -%}
+      alter schema {{ relation.without_identifier().include(database=False) }}
+      owner to {{ adapter.quote(configured_owner) }}
+    {%- endcall -%}
+  {%- endif -%}
+{% endmacro %}
+
 {% macro risingwave__get_columns_in_relation(relation) -%}
   {% call statement('get_columns_in_relation', fetch_result=True) %}
       select

--- a/dbt/include/risingwave/macros/materializations/grants.sql
+++ b/dbt/include/risingwave/macros/materializations/grants.sql
@@ -2,6 +2,26 @@
    The default dbt macro emits `GRANT x ON relation` which RisingWave rejects
    for non-table objects. These overrides add the correct ON <type> clause. #}
 
+{% macro risingwave__get_show_grant_sql(relation) %}
+  with relation_acl as (
+    select
+      unnest(rw_relations.acl) as acl_entry
+    from rw_catalog.rw_relations
+    join rw_catalog.rw_schemas on rw_relations.schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ relation.schema }}'
+      and rw_relations.name = '{{ relation.identifier }}'
+  )
+  select
+    split_part(acl_entry, '=', 1) as grantee,
+    case
+      when split_part(split_part(acl_entry, '=', 2), '/', 1) = 'dwar' then 'all'
+      when split_part(split_part(acl_entry, '=', 2), '/', 1) like '%r%' then 'select'
+    end as privilege_type
+  from relation_acl
+  where split_part(acl_entry, '=', 1) not in ('root', 'rwadmin', 'postgres')
+    and split_part(split_part(acl_entry, '=', 2), '/', 1) like '%r%'
+{% endmacro %}
+
 {%- macro risingwave__get_grant_sql(relation, privilege, grantees) -%}
     grant {{ privilege }} on
     {%- if relation.type == 'materialized_view' %} materialized view

--- a/dbt/include/risingwave/macros/materializations/materialized_view.sql
+++ b/dbt/include/risingwave/macros/materializations/materialized_view.sql
@@ -22,6 +22,8 @@
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
+  {{ risingwave__ensure_schema_authorization(target_relation) }}
+
   {% if old_relation is none %}
     {# First time creation #}
     {% call statement('main') -%}

--- a/dbt/include/risingwave/macros/materializations/table.sql
+++ b/dbt/include/risingwave/macros/materializations/table.sql
@@ -8,6 +8,7 @@
                                                 schema=schema,
                                                 database=database,
                                                 type='table') -%}
+  {%- set grant_config = config.get('grants') -%}
 
   {% if full_refresh_mode and old_relation %}
     {{ adapter.drop_relation(old_relation) }}
@@ -15,6 +16,8 @@
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {{ risingwave__ensure_schema_authorization(target_relation) }}
 
   {% if old_relation is none or (full_refresh_mode and old_relation) %}
     {% call statement('main') -%}
@@ -27,6 +30,9 @@
   {% else %}
     {{ risingwave__execute_no_op(target_relation) }}
   {% endif %}
+
+  {% set should_revoke = should_revoke(existing_relation=old_relation, full_refresh_mode=full_refresh_mode) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
   {% do persist_docs(target_relation, model) %}
 

--- a/dbt/include/risingwave/macros/materializations/view.sql
+++ b/dbt/include/risingwave/macros/materializations/view.sql
@@ -6,6 +6,7 @@
                                                 database=database,
                                                 type='view') -%}
   {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
+  {%- set grant_config = config.get('grants') -%}
 
   {# Check both model config AND command line flag for zero downtime #}
   {%- set zero_downtime_config = config.get('zero_downtime', {}) -%}
@@ -20,6 +21,8 @@
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {{ risingwave__ensure_schema_authorization(target_relation) }}
 
   {% if old_relation is none %}
     {# First time creation #}
@@ -71,6 +74,9 @@
       {{ risingwave__handle_on_configuration_change(old_relation, target_relation) }}
     {% endif %}
   {% endif %}
+
+  {% set should_revoke = should_revoke(existing_relation=old_relation, full_refresh_mode=full_refresh_mode) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
   {% do persist_docs(target_relation, model) %}
 

--- a/tests/e2e/grants_docs_schema/dbt_project.yml
+++ b/tests/e2e/grants_docs_schema/dbt_project.yml
@@ -1,0 +1,18 @@
+name: dbt_risingwave_grants_docs_schema
+version: "1.0"
+config-version: 2
+
+profile: dbt_risingwave_grants_docs_schema
+
+model-paths: ["models"]
+macro-paths: ["macros"]
+test-paths: ["tests"]
+
+models:
+  dbt_risingwave_grants_docs_schema:
+    +persist_docs:
+      relation: true
+      columns: true
+    +schema_authorization: dbt_e2e_gds_owner
+    +grants:
+      select: ["dbt_e2e_gds_grantee"]

--- a/tests/e2e/grants_docs_schema/macros/prepare_grants_docs_schema.sql
+++ b/tests/e2e/grants_docs_schema/macros/prepare_grants_docs_schema.sql
@@ -1,0 +1,9 @@
+{% macro prepare_grants_docs_schema() %}
+  {% call statement('prepare_grants_docs_schema') %}
+    drop schema if exists {{ adapter.quote(target.schema) }} cascade;
+    drop user if exists dbt_e2e_gds_grantee;
+    drop user if exists dbt_e2e_gds_owner;
+    create user dbt_e2e_gds_grantee;
+    create user dbt_e2e_gds_owner;
+  {% endcall %}
+{% endmacro %}

--- a/tests/e2e/grants_docs_schema/models/docs_base_mv.sql
+++ b/tests/e2e/grants_docs_schema/models/docs_base_mv.sql
@@ -1,0 +1,6 @@
+{{ config(materialized='materialized_view') }}
+
+select
+    id,
+    payload || '_mv' as payload
+from {{ ref('docs_base_view') }}

--- a/tests/e2e/grants_docs_schema/models/docs_base_table.sql
+++ b/tests/e2e/grants_docs_schema/models/docs_base_table.sql
@@ -1,0 +1,9 @@
+{{ config(materialized='table') }}
+
+select
+    1 as id,
+    'alpha'::varchar as payload
+union all
+select
+    2 as id,
+    'beta'::varchar as payload

--- a/tests/e2e/grants_docs_schema/models/docs_base_view.sql
+++ b/tests/e2e/grants_docs_schema/models/docs_base_view.sql
@@ -1,0 +1,9 @@
+{{ config(
+    materialized='view',
+    persist_docs={'relation': false, 'columns': false}
+) }}
+
+select
+    id,
+    payload || '_view' as payload
+from {{ ref('docs_base_table') }}

--- a/tests/e2e/grants_docs_schema/models/models.yml
+++ b/tests/e2e/grants_docs_schema/models/models.yml
@@ -1,0 +1,26 @@
+version: 2
+
+models:
+  - name: docs_base_table
+    description: Table relation comment from persist_docs.
+    columns:
+      - name: id
+        description: Table id column comment from persist_docs.
+      - name: payload
+        description: Table payload column comment from persist_docs.
+
+  - name: docs_base_view
+    description: View relation comment from persist_docs.
+    columns:
+      - name: id
+        description: View id column comment from persist_docs.
+      - name: payload
+        description: View payload column comment from persist_docs.
+
+  - name: docs_base_mv
+    description: Materialized view relation comment from persist_docs.
+    columns:
+      - name: id
+        description: Materialized view id column comment from persist_docs.
+      - name: payload
+        description: Materialized view payload column comment from persist_docs.

--- a/tests/e2e/grants_docs_schema/tests/assert_grants_docs_schema.sql
+++ b/tests/e2e/grants_docs_schema/tests/assert_grants_docs_schema.sql
@@ -1,0 +1,127 @@
+with target_schema as (
+    select
+        rw_schemas.id,
+        rw_schemas.name,
+        rw_users.name as owner_name
+    from rw_catalog.rw_schemas
+    join rw_catalog.rw_users on rw_schemas.owner = rw_users.id
+    where rw_schemas.name = '{{ target.schema }}'
+),
+target_relations as (
+    select
+        rw_relations.id,
+        rw_relations.name,
+        rw_relations.relation_type,
+        rw_relations.acl
+    from rw_catalog.rw_relations
+    join target_schema on rw_relations.schema_id = target_schema.id
+    where rw_relations.name in ('docs_base_table', 'docs_base_view', 'docs_base_mv')
+),
+relation_comments as (
+    select
+        target_relations.name,
+        rw_description.description
+    from target_relations
+    join rw_catalog.rw_description
+      on rw_description.objoid = target_relations.id
+     and rw_description.objsubid is null
+),
+column_comments as (
+    select
+        target_relations.name as relation_name,
+        rw_columns.name as column_name,
+        rw_description.description
+    from target_relations
+    join rw_catalog.rw_columns
+      on rw_columns.relation_id = target_relations.id
+    left join rw_catalog.rw_description
+      on rw_description.objoid = target_relations.id
+     and rw_description.objsubid = rw_columns.position
+)
+select 'target schema owner mismatch' as failure
+where not exists (
+    select 1
+    from target_schema
+    where owner_name = 'dbt_e2e_gds_owner'
+)
+
+union all
+
+select 'docs_base_table must be a table' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_base_table'
+      and relation_type = 'table'
+)
+
+union all
+
+select 'docs_base_view must be a view' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_base_view'
+      and relation_type = 'view'
+)
+
+union all
+
+select 'docs_base_mv must be a materialized view' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_base_mv'
+      and relation_type = 'materialized view'
+)
+
+union all
+
+select 'docs_base_table grant missing' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_base_table'
+      and array_to_string(acl, ',') like '%dbt_e2e_gds_grantee=r/%'
+)
+
+union all
+
+select 'docs_base_view grant missing' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_base_view'
+      and array_to_string(acl, ',') like '%dbt_e2e_gds_grantee=r/%'
+)
+
+union all
+
+select 'docs_base_mv grant missing' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_base_mv'
+      and array_to_string(acl, ',') like '%dbt_e2e_gds_grantee=r/%'
+)
+
+union all
+
+select 'docs_base_table relation comment mismatch' as failure
+where not exists (
+    select 1
+    from relation_comments
+    where name = 'docs_base_table'
+      and description = 'Table relation comment from persist_docs.'
+)
+
+union all
+
+select 'docs_base_table id comment mismatch' as failure
+where not exists (
+    select 1
+    from column_comments
+    where relation_name = 'docs_base_table'
+      and column_name = 'id'
+      and description = 'Table id column comment from persist_docs.'
+)


### PR DESCRIPTION
## Summary
- Add an isolated `tests/e2e/grants_docs_schema` fixture that covers `schema_authorization`, `grants`, and `persist_docs` on live RisingWave.
- Add a `test-grants-docs-schema` CI job that prepares test roles/schema, runs full-refresh, verifies existing-relation no-op runs, tests catalog state, and generates docs.
- Fill adapter gaps surfaced by the e2e: apply grants for `table` and `view` materializations, refresh schema ownership for `schema_authorization`, and read existing grants from `rw_catalog.rw_relations.acl` instead of unsupported `information_schema.role_table_grants`.

## Validation
- `DBT_PROFILES_DIR=/tmp/dbt-risingwave-grants-profiles dbt run-operation prepare_grants_docs_schema`
- `DBT_PROFILES_DIR=/tmp/dbt-risingwave-grants-profiles dbt run --full-refresh`
- `DBT_PROFILES_DIR=/tmp/dbt-risingwave-grants-profiles dbt test`
- `DBT_PROFILES_DIR=/tmp/dbt-risingwave-grants-profiles dbt run`
- `DBT_PROFILES_DIR=/tmp/dbt-risingwave-grants-profiles dbt test`
- `DBT_PROFILES_DIR=/tmp/dbt-risingwave-grants-profiles dbt docs generate`
- `ruby -e 'require "yaml"; y=YAML.load_file(".github/workflows/ci.yml"); abort("missing") unless y.fetch("jobs").key?("test-grants-docs-schema"); puts "ci yaml ok"'`
- `git diff --check`
