### PR TITLE
test: add hooks sql header e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -720,3 +720,52 @@ jobs:
         dbt test
         dbt docs generate
       working-directory: tests/e2e/source_connection
+
+  test-hooks-sql-header:
+    runs-on: ubuntu-latest
+    services:
+      risingwave:
+        image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        ports:
+          - 4566:4566
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Setup dbt profile
+      run: |
+        mkdir -p $HOME/.dbt && cat >> $HOME/.dbt/profiles.yml <<EOF
+        dbt_risingwave_hooks_sql_header:
+          outputs:
+            dev:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dev
+              port: 4566
+              schema: dbt_e2e_hooks_sql_header
+          target: dev
+        EOF
+    - name: Install current adapter
+      run: python3 -m pip install .
+    - name: Wait for RisingWave to be ready
+      run: timeout 60 bash -c 'until nc -z 127.0.0.1 4566; do sleep 1; done'
+    - name: dbt-run
+      run: dbt run --full-refresh
+      working-directory: tests/e2e/hooks_sql_header
+    - name: dbt-test
+      run: dbt test
+      working-directory: tests/e2e/hooks_sql_header
+    - name: dbt-run-existing-relations
+      run: dbt run
+      working-directory: tests/e2e/hooks_sql_header
+    - name: dbt-test-existing-relations
+      run: dbt test
+      working-directory: tests/e2e/hooks_sql_header
+    - name: dbt-doc
+      run: dbt docs generate
+      working-directory: tests/e2e/hooks_sql_header

--- a/tests/e2e/hooks_sql_header/dbt_project.yml
+++ b/tests/e2e/hooks_sql_header/dbt_project.yml
@@ -1,0 +1,8 @@
+name: dbt_risingwave_hooks_sql_header
+version: "1.0"
+config-version: 2
+
+profile: dbt_risingwave_hooks_sql_header
+
+model-paths: ["models"]
+test-paths: ["tests"]

--- a/tests/e2e/hooks_sql_header/models/hook_mv_model.sql
+++ b/tests/e2e/hooks_sql_header/models/hook_mv_model.sql
@@ -1,0 +1,11 @@
+{{ config(
+    materialized='materialized_view',
+    pre_hook=[
+        "create table if not exists {{ target.schema }}.hook_audit (event varchar, model_name varchar)",
+        "insert into {{ target.schema }}.hook_audit values ('pre', 'hook_mv_model')"
+    ],
+    post_hook="insert into {{ target.schema }}.hook_audit values ('post', 'hook_mv_model')",
+    sql_header="insert into " ~ target.schema ~ ".hook_audit values ('sql_header', 'hook_mv_model');"
+) }}
+
+select 3 as id, 'materialized_view' as materialization_kind

--- a/tests/e2e/hooks_sql_header/models/hook_table_model.sql
+++ b/tests/e2e/hooks_sql_header/models/hook_table_model.sql
@@ -1,0 +1,11 @@
+{{ config(
+    materialized='table',
+    pre_hook=[
+        "create table if not exists {{ target.schema }}.hook_audit (event varchar, model_name varchar)",
+        "insert into {{ target.schema }}.hook_audit values ('pre', 'hook_table_model')"
+    ],
+    post_hook="insert into {{ target.schema }}.hook_audit values ('post', 'hook_table_model')",
+    sql_header="insert into " ~ target.schema ~ ".hook_audit values ('sql_header', 'hook_table_model');"
+) }}
+
+select 1 as id, 'table' as materialization_kind

--- a/tests/e2e/hooks_sql_header/models/hook_view_model.sql
+++ b/tests/e2e/hooks_sql_header/models/hook_view_model.sql
@@ -1,0 +1,11 @@
+{{ config(
+    materialized='view',
+    pre_hook=[
+        "create table if not exists {{ target.schema }}.hook_audit (event varchar, model_name varchar)",
+        "insert into {{ target.schema }}.hook_audit values ('pre', 'hook_view_model')"
+    ],
+    post_hook="insert into {{ target.schema }}.hook_audit values ('post', 'hook_view_model')",
+    sql_header="insert into " ~ target.schema ~ ".hook_audit values ('sql_header', 'hook_view_model');"
+) }}
+
+select 2 as id, 'view' as materialization_kind

--- a/tests/e2e/hooks_sql_header/tests/assert_hooks_sql_header.sql
+++ b/tests/e2e/hooks_sql_header/tests/assert_hooks_sql_header.sql
@@ -1,0 +1,64 @@
+with expected as (
+    select *
+    from (
+        values
+            ('pre', 'hook_table_model'),
+            ('sql_header', 'hook_table_model'),
+            ('post', 'hook_table_model'),
+            ('pre', 'hook_view_model'),
+            ('sql_header', 'hook_view_model'),
+            ('post', 'hook_view_model'),
+            ('pre', 'hook_mv_model'),
+            ('sql_header', 'hook_mv_model'),
+            ('post', 'hook_mv_model')
+    ) as t(event, model_name)
+),
+missing_events as (
+    select
+        'missing hook event: ' || event || ' / ' || model_name as failure
+    from expected
+    where not exists (
+        select 1
+        from {{ target.schema }}.hook_audit as hook_audit
+        where hook_audit.event = expected.event
+          and hook_audit.model_name = expected.model_name
+    )
+),
+missing_created_relations as (
+    select 'hook_table_model should be a table' as failure
+    where not exists (
+        select 1
+        from rw_catalog.rw_relations
+        join rw_catalog.rw_schemas on schema_id = rw_schemas.id
+        where rw_schemas.name = '{{ target.schema }}'
+          and rw_relations.name = 'hook_table_model'
+          and rw_relations.relation_type = 'table'
+    )
+
+    union all
+
+    select 'hook_view_model should be a view' as failure
+    where not exists (
+        select 1
+        from rw_catalog.rw_relations
+        join rw_catalog.rw_schemas on schema_id = rw_schemas.id
+        where rw_schemas.name = '{{ target.schema }}'
+          and rw_relations.name = 'hook_view_model'
+          and rw_relations.relation_type = 'view'
+    )
+
+    union all
+
+    select 'hook_mv_model should be a materialized view' as failure
+    where not exists (
+        select 1
+        from rw_catalog.rw_relations
+        join rw_catalog.rw_schemas on schema_id = rw_schemas.id
+        where rw_schemas.name = '{{ target.schema }}'
+          and rw_relations.name = 'hook_mv_model'
+          and rw_relations.relation_type = 'materialized view'
+    )
+)
+select failure from missing_events
+union all
+select failure from missing_created_relations


### PR DESCRIPTION
## Summary
- add a dedicated `tests/e2e/hooks_sql_header` fixture
- cover `pre_hook`, `post_hook`, and `sql_header` on table, view, and materialized view models
- add a `test-hooks-sql-header` CI job that validates first creation, existing-relation rerun, catalog assertions, and docs generation

## Validation
- local: `dbt parse`
- local: `dbt run --full-refresh`
- local: `dbt test`
- local: `dbt run`
- local: `dbt test`
- local: `dbt docs generate`
- local: `git diff --check`
- local: workflow YAML parse for `test-hooks-sql-header`