### PR TITLE
test: add seeds ephemeral snapshots e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -769,3 +769,52 @@ jobs:
     - name: dbt-doc
       run: dbt docs generate
       working-directory: tests/e2e/hooks_sql_header
+
+  test-seeds-ephemeral-snapshots:
+    runs-on: ubuntu-latest
+    services:
+      risingwave:
+        image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        ports:
+          - 4566:4566
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Setup dbt profile
+      run: |
+        mkdir -p $HOME/.dbt && cat >> $HOME/.dbt/profiles.yml <<EOF
+        dbt_risingwave_seeds_ephemeral_snapshots:
+          outputs:
+            dev:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dev
+              port: 4566
+              schema: dbt_e2e_seeds_ephemeral_snapshots
+          target: dev
+        EOF
+    - name: Install current adapter
+      run: python3 -m pip install .
+    - name: Wait for RisingWave to be ready
+      run: timeout 60 bash -c 'until nc -z 127.0.0.1 4566; do sleep 1; done'
+    - name: dbt-seed
+      run: dbt seed --full-refresh
+      working-directory: tests/e2e/seeds_ephemeral_snapshots
+    - name: dbt-run
+      run: dbt run --full-refresh
+      working-directory: tests/e2e/seeds_ephemeral_snapshots
+    - name: dbt-snapshot
+      run: dbt snapshot
+      working-directory: tests/e2e/seeds_ephemeral_snapshots
+    - name: dbt-test
+      run: dbt test
+      working-directory: tests/e2e/seeds_ephemeral_snapshots
+    - name: dbt-doc
+      run: dbt docs generate
+      working-directory: tests/e2e/seeds_ephemeral_snapshots

--- a/tests/e2e/seeds_ephemeral_snapshots/dbt_project.yml
+++ b/tests/e2e/seeds_ephemeral_snapshots/dbt_project.yml
@@ -1,0 +1,22 @@
+name: dbt_risingwave_seeds_ephemeral_snapshots
+version: "1.0"
+config-version: 2
+
+profile: dbt_risingwave_seeds_ephemeral_snapshots
+
+model-paths: ["models"]
+seed-paths: ["seeds"]
+snapshot-paths: ["snapshots"]
+test-paths: ["tests"]
+
+seeds:
+  dbt_risingwave_seeds_ephemeral_snapshots:
+    seed_users:
+      +column_types:
+        id: integer
+        name: varchar
+        status: varchar
+
+snapshots:
+  dbt_risingwave_seeds_ephemeral_snapshots:
+    +target_schema: "{{ target.schema }}"

--- a/tests/e2e/seeds_ephemeral_snapshots/models/active_user_summary.sql
+++ b/tests/e2e/seeds_ephemeral_snapshots/models/active_user_summary.sql
@@ -1,0 +1,7 @@
+{{ config(materialized='table') }}
+
+select
+    id,
+    name_upper
+from {{ ref('ephemeral_active_users') }}
+order by id

--- a/tests/e2e/seeds_ephemeral_snapshots/models/ephemeral_active_users.sql
+++ b/tests/e2e/seeds_ephemeral_snapshots/models/ephemeral_active_users.sql
@@ -1,0 +1,9 @@
+{{ config(materialized='ephemeral') }}
+
+select
+    id,
+    name,
+    status,
+    upper(name) as name_upper
+from {{ ref('seed_users') }}
+where status = 'active'

--- a/tests/e2e/seeds_ephemeral_snapshots/seeds/seed_users.csv
+++ b/tests/e2e/seeds_ephemeral_snapshots/seeds/seed_users.csv
@@ -1,0 +1,4 @@
+id,name,status
+1,Alice,active
+2,Bob,active
+3,Carla,inactive

--- a/tests/e2e/seeds_ephemeral_snapshots/snapshots/seed_users_snapshot.sql
+++ b/tests/e2e/seeds_ephemeral_snapshots/snapshots/seed_users_snapshot.sql
@@ -1,0 +1,18 @@
+{% snapshot seed_users_snapshot %}
+
+{{
+    config(
+        target_schema=target.schema,
+        unique_key='id',
+        strategy='check',
+        check_cols=['name', 'status']
+    )
+}}
+
+select
+    id,
+    name,
+    status
+from {{ ref('seed_users') }}
+
+{% endsnapshot %}

--- a/tests/e2e/seeds_ephemeral_snapshots/tests/assert_seed_ephemeral_snapshot.sql
+++ b/tests/e2e/seeds_ephemeral_snapshots/tests/assert_seed_ephemeral_snapshot.sql
@@ -1,0 +1,55 @@
+with failures as (
+    select 'seed_users should contain the seeded rows' as failure
+    where (
+        select count(*)
+        from {{ target.schema }}.seed_users
+    ) != 3
+
+    union all
+
+    select 'active_user_summary should materialize the ephemeral model output' as failure
+    where not exists (
+        select 1
+        from {{ target.schema }}.active_user_summary
+        where id = 1
+          and name_upper = 'ALICE'
+    )
+
+    union all
+
+    select 'active_user_summary should not include inactive users after the initial run' as failure
+    where exists (
+        select 1
+        from {{ target.schema }}.active_user_summary
+        where id = 3
+    )
+
+    union all
+
+    select 'ephemeral_active_users should not be created as a relation' as failure
+    where exists (
+        select 1
+        from rw_catalog.rw_relations
+        join rw_catalog.rw_schemas on schema_id = rw_schemas.id
+        where rw_schemas.name = '{{ target.schema }}'
+          and rw_relations.name = 'ephemeral_active_users'
+    )
+
+    union all
+
+    select 'snapshot should contain the initial seeded rows' as failure
+    where (
+        select count(*)
+        from {{ target.schema }}.seed_users_snapshot
+    ) != 3
+
+    union all
+
+    select 'snapshot should have current rows for all seeded users' as failure
+    where (
+        select count(*)
+        from {{ target.schema }}.seed_users_snapshot
+        where dbt_valid_to is null
+    ) != 3
+)
+select * from failures


### PR DESCRIPTION
## Summary
- add a dedicated `tests/e2e/seeds_ephemeral_snapshots` fixture
- cover `dbt seed`, an ephemeral model consumed by a table model, and initial `dbt snapshot` creation
- add a `test-seeds-ephemeral-snapshots` CI job that runs parse/seed/run/snapshot/test/docs through the current adapter

## Current contract
This PR intentionally covers the stable snapshot path: first-time snapshot creation/initialization. Snapshot update/re-run after source data changes is not included because dbt currently generates `UPDATE ... FROM` for that path, which RisingWave rejects today with a SQL parser error. That should be handled as a separate adapter/RisingWave compatibility fix instead of being hidden inside this e2e coverage PR.

## Validation
- `ruby -e 'require "yaml"; y=YAML.load_file(".github/workflows/ci.yml"); abort("missing") unless y.fetch("jobs").key?("test-seeds-ephemeral-snapshots")'`
- `git diff --check`
- local RisingWave on `localhost:4566`:
  - `dbt parse`
  - `dbt seed --full-refresh`
  - `dbt run --full-refresh`
  - `dbt snapshot`
  - `dbt test`
  - `dbt docs generate`
