### PR TITLE
fix: use catalog lookup for streaming materializations

### DIFF
--- a/dbt/include/risingwave/macros/materializations/sink.sql
+++ b/dbt/include/risingwave/macros/materializations/sink.sql
@@ -1,21 +1,15 @@
 {% materialization sink, adapter = "risingwave" %}
     {%- set identifier = model["alias"] -%}
     {%- set full_refresh_mode = should_full_refresh() -%}
-    {%- set old_relation = adapter.get_relation(
-        identifier=identifier,
-        schema=schema,
-        database=database,
-    ) -%}
     {%- set target_relation = api.Relation.create(
         identifier=identifier,
         schema=schema,
         database=database,
         type="sink",
     ) -%}
+    {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
 
-    {% if full_refresh_mode and old_relation %}
-      {{ adapter.drop_relation(old_relation) }}
-    {% endif %}
+    {% if full_refresh_mode and old_relation %} {{ adapter.drop_relation(old_relation) }} {% endif %}
 
     {{ run_hooks(pre_hooks, inside_transaction=False) }}
     {{ run_hooks(pre_hooks, inside_transaction=True) }}
@@ -23,15 +17,12 @@
     {% if old_relation is none or (full_refresh_mode and old_relation) %}
         {%- set connector = config.get("connector") -%}
         {% call statement("main") -%}
-            {% if connector %}
-              {{ risingwave__create_sink(target_relation, sql) }}
-            {% else %}
-              {{ risingwave__run_sql(sql) }}
+            {% if connector %} {{ risingwave__create_sink(target_relation, sql) }}
+            {% else %} {{ risingwave__run_sql(sql) }}
             {% endif %}
         {%- endcall %}
-        {{ risingwave__wait_for_background_ddl(target_relation, 'sink') }}
-    {% else %}
-      {{ risingwave__execute_no_op(target_relation) }}
+        {{ risingwave__wait_for_background_ddl(target_relation, "sink") }}
+    {% else %} {{ risingwave__execute_no_op(target_relation) }}
     {% endif %}
 
     {% do persist_docs(target_relation, model) %}

--- a/dbt/include/risingwave/macros/materializations/source.sql
+++ b/dbt/include/risingwave/macros/materializations/source.sql
@@ -1,33 +1,25 @@
-{% materialization source, adapter='risingwave' %}
-  {%- set identifier = model['alias'] -%}
-  {%- set full_refresh_mode = should_full_refresh() -%}
-  {%- set old_relation = adapter.get_relation(identifier=identifier,
-                                              schema=schema,
-                                              database=database) -%}
-  {%- set target_relation = api.Relation.create(identifier=identifier,
-                                                schema=schema,
-                                                database=database,
-                                                type='source') -%}
+{% materialization source, adapter = "risingwave" %}
+    {%- set identifier = model["alias"] -%}
+    {%- set full_refresh_mode = should_full_refresh() -%}
+    {%- set target_relation = api.Relation.create(
+        identifier=identifier, schema=schema, database=database, type="source"
+    ) -%}
+    {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
 
-  {% if full_refresh_mode and old_relation %}
-    {{ adapter.drop_relation(old_relation) }}
-  {% endif %}
+    {% if full_refresh_mode and old_relation %} {{ adapter.drop_relation(old_relation) }} {% endif %}
 
-  {{ run_hooks(pre_hooks, inside_transaction=False) }}
-  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+    {{ run_hooks(pre_hooks, inside_transaction=False) }}
+    {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-  {% if old_relation is none or (full_refresh_mode and old_relation) %}
-    {% call statement('main') -%}
-      {{ risingwave__run_sql(sql) }}
-    {%- endcall %}
-  {% else %}
-    {{ risingwave__execute_no_op(target_relation) }}
-  {% endif %}
+    {% if old_relation is none or (full_refresh_mode and old_relation) %}
+        {% call statement("main") -%} {{ risingwave__run_sql(sql) }} {%- endcall %}
+    {% else %} {{ risingwave__execute_no_op(target_relation) }}
+    {% endif %}
 
-  {% do persist_docs(target_relation, model) %}
+    {% do persist_docs(target_relation, model) %}
 
-  {{ run_hooks(post_hooks, inside_transaction=False) }}
-  {{ run_hooks(post_hooks, inside_transaction=True) }}
+    {{ run_hooks(post_hooks, inside_transaction=False) }}
+    {{ run_hooks(post_hooks, inside_transaction=True) }}
 
-  {{ return({'relations': [target_relation]}) }}
+    {{ return({"relations": [target_relation]}) }}
 {% endmaterialization %}

--- a/dbt/include/risingwave/macros/materializations/table_with_connector.sql
+++ b/dbt/include/risingwave/macros/materializations/table_with_connector.sql
@@ -1,44 +1,34 @@
-{% materialization table_with_connector, adapter='risingwave' %}
-  {%- set identifier = model['alias'] -%}
-  {%- set full_refresh_mode = should_full_refresh() -%}
-  {%- set old_relation = adapter.get_relation(identifier=identifier,
-                                              schema=schema,
-                                              database=database) -%}
-  {%- set target_relation = api.Relation.create(identifier=identifier,
-                                                schema=schema,
-                                                database=database,
-                                                type='table') -%}
+{% materialization table_with_connector, adapter = "risingwave" %}
+    {%- set identifier = model["alias"] -%}
+    {%- set full_refresh_mode = should_full_refresh() -%}
+    {%- set target_relation = api.Relation.create(
+        identifier=identifier, schema=schema, database=database, type="table"
+    ) -%}
+    {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
 
-  {% if full_refresh_mode and old_relation %}
-    {{ adapter.drop_relation(old_relation) }}
-  {% endif %}
+    {% if full_refresh_mode and old_relation %} {{ adapter.drop_relation(old_relation) }} {% endif %}
 
-  {{ run_hooks(pre_hooks, inside_transaction=False) }}
-  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+    {{ run_hooks(pre_hooks, inside_transaction=False) }}
+    {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-  {% if old_relation is none or (full_refresh_mode and old_relation) %}
-    {% call statement('main') -%}
-      {{ risingwave__run_sql(sql) }}
-    {%- endcall %}
+    {% if old_relation is none or (full_refresh_mode and old_relation) %}
+        {% call statement("main") -%} {{ risingwave__run_sql(sql) }} {%- endcall %}
 
-    {{ create_indexes(target_relation) }}
-  {% else %}
-    {% set applied_table_schema_change = risingwave__handle_table_with_connector_on_schema_change(target_relation) %}
-    {{ risingwave__handle_on_configuration_change(old_relation, target_relation) }}
-    {% if applied_table_schema_change %}
-      {% do store_raw_result(
-          name="main",
-          message="ALTER_TABLE",
-          code="ALTER_TABLE",
-          rows_affected="-1"
-      ) %}
+        {{ create_indexes(target_relation) }}
+    {% else %}
+        {% set applied_table_schema_change = risingwave__handle_table_with_connector_on_schema_change(
+            target_relation
+        ) %}
+        {{ risingwave__handle_on_configuration_change(old_relation, target_relation) }}
+        {% if applied_table_schema_change %}
+            {% do store_raw_result(name="main", message="ALTER_TABLE", code="ALTER_TABLE", rows_affected="-1") %}
+        {% endif %}
     {% endif %}
-  {% endif %}
 
-  {% do persist_docs(target_relation, model) %}
+    {% do persist_docs(target_relation, model) %}
 
-  {{ run_hooks(post_hooks, inside_transaction=False) }}
-  {{ run_hooks(post_hooks, inside_transaction=True) }}
+    {{ run_hooks(post_hooks, inside_transaction=False) }}
+    {{ run_hooks(post_hooks, inside_transaction=True) }}
 
-  {{ return({'relations': [target_relation]}) }}
+    {{ return({"relations": [target_relation]}) }}
 {% endmaterialization %}

--- a/tests/unit/test_materialization_relation_lookup.py
+++ b/tests/unit/test_materialization_relation_lookup.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+MATERIALIZATION_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "dbt"
+    / "include"
+    / "risingwave"
+    / "macros"
+    / "materializations"
+)
+
+
+def test_connector_materializations_use_catalog_relation_lookup():
+    for filename in ("table_with_connector.sql", "sink.sql", "source.sql"):
+        materialization = (MATERIALIZATION_DIR / filename).read_text()
+
+        assert "risingwave__get_relation_without_caching(target_relation)" in materialization
+        assert "adapter.get_relation" not in materialization


### PR DESCRIPTION
## Summary

Fixes reruns for RisingWave streaming materializations that need to detect already-existing catalog objects before deciding whether to create or no-op.

This changes `table_with_connector`, `sink`, and `source` to use the adapter's catalog-backed `risingwave__get_relation_without_caching(target_relation)` helper instead of `adapter.get_relation(...)`.

## What was broken

In a bootstrap-style dbt project, the first run creates connector tables, sources, materialized views, and sinks. A second run should be safe: existing objects should be detected and skipped unless `--full-refresh` is explicitly requested.

The stock `table_with_connector` and `sink` materializations were using `adapter.get_relation(...)` for existence checks. In the live-ingestion migration this was not reliable for all RisingWave streaming object types on a rerun, so dbt sometimes entered the create branch again and attempted to recreate objects that already existed. That made bootstrap reruns fail instead of being idempotent.

The adapter already has a RisingWave-specific catalog lookup helper, `risingwave__get_relation_without_caching`, which queries RisingWave catalog state and normalizes relation types including `sink` and `materialized view`. `materialized_view` and `view` already use this helper; this PR extends that same pattern to the other raw-DDL streaming materializations.

## Why this fix

Using the RisingWave catalog lookup keeps the behavior inside the adapter instead of forcing downstream projects to generate custom materialization overrides. It makes bootstrap reruns deterministic:

- if the target relation does not exist, dbt runs the model DDL
- if it already exists and this is not full-refresh, dbt no-ops/skips
- if full-refresh is requested, the existing relation is dropped first and recreated

This lets downstream projects remove workaround macros that only existed to compensate for unreliable existence detection.

## Changed

- `table_with_connector` now builds `target_relation` first and resolves `old_relation` through `risingwave__get_relation_without_caching(target_relation)`.
- `sink` now uses the same catalog-backed lookup.
- `source` now uses the same catalog-backed lookup for consistency with other raw-DDL streaming materializations.
- Added a small unit regression test that prevents these materializations from drifting back to `adapter.get_relation(...)`.

## Validation

- `pre-commit run --files dbt/include/risingwave/macros/materializations/sink.sql dbt/include/risingwave/macros/materializations/source.sql dbt/include/risingwave/macros/materializations/table_with_connector.sql tests/unit/test_materialization_relation_lookup.py`
- `python3` dependency-free regression check for the same materialization assertions
- `pytest --confcutdir=tests/unit tests/unit/test_materialization_relation_lookup.py` in a temporary venv

Note: plain pytest collection without `--confcutdir=tests/unit` requires the repo's full dbt test fixture dependencies (`dbt.tests.fixtures.project`), so the focused unit test was run isolated from the top-level e2e fixture plugin.