### PR TITLE
ci: run tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Test dbt-risingwave
 
-on: [push]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   test-with-jaffle_shop:


### PR DESCRIPTION
## Summary
- run the existing dbt-risingwave CI workflow for pull_request events
- keep push runs and add workflow_dispatch for manual reruns

## Why
External contributor PRs currently do not trigger the test workflow because it only listens to push events. Enabling pull_request lets review-required PRs surface CI before merge.

## Validation
- python3 inline workflow trigger check
- git diff --check