### PR TITLE
Add RisingWave subscription materialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,60 @@ jobs:
       run: dbt docs generate
       working-directory: tests/e2e/sinks
 
+  test-subscriptions:
+    runs-on: ubuntu-latest
+    services:
+      risingwave:
+        image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        ports:
+          - 4566:4566
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Setup dbt profile
+      run: |
+        mkdir -p $HOME/.dbt && cat >> $HOME/.dbt/profiles.yml <<EOF
+        dbt_risingwave_subscriptions:
+          outputs:
+            dev:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dev
+              port: 4566
+              schema: public
+            downstream:
+              type: risingwave
+              host: 127.0.0.1
+              user: root
+              pass: ""
+              dbname: dbt_subscription_downstream
+              port: 4566
+              schema: public
+          target: dev
+        EOF
+    - name: Install current adapter
+      run: python3 -m pip install .
+    - name: Wait for RisingWave to be ready
+      run: timeout 60 bash -c 'until nc -z 127.0.0.1 4566; do sleep 1; done'
+    - name: prepare-downstream-database
+      run: dbt run-operation prepare_subscription_downstream_database --target dev
+      working-directory: tests/e2e/subscriptions
+    - name: dbt-build-upstream
+      run: dbt build --full-refresh --no-partial-parse --target dev --select tag:upstream
+      working-directory: tests/e2e/subscriptions
+    - name: dbt-build-downstream
+      run: dbt build --full-refresh --no-partial-parse --target downstream --select tag:downstream
+      working-directory: tests/e2e/subscriptions
+    - name: dbt-doc
+      run: dbt docs generate --no-partial-parse --target dev
+      working-directory: tests/e2e/subscriptions
+
   test-incremental:
     runs-on: ubuntu-latest
     services:

--- a/README.md
+++ b/README.md
@@ -160,8 +160,9 @@ from {{ ref('events') }}
 | `source` | Runs a full `CREATE SOURCE` statement supplied by the model SQL. |
 | `table_with_connector` | Runs a full `CREATE TABLE ... WITH (...)` statement supplied by the model SQL. Supports explicit additive `ALTER TABLE ADD COLUMN` changes through `on_schema_change='append_new_columns'`. |
 | `sink` | Creates a sink, either from adapter configs or from a full SQL statement. |
+| `subscription` | Creates a RisingWave subscription from a relation rendered by the model SQL, usually `ref()`. This is useful for maintaining the upstream log store needed by cross-database materialized views. |
 
-See [docs/configuration.md](docs/configuration.md) for adapter-specific configuration examples, including streaming session settings and background DDL.
+See [docs/configuration.md](docs/configuration.md) for adapter-specific configuration examples, including streaming session settings, background DDL, sinks, and subscriptions.
 
 ## Documentation
 

--- a/dbt/adapters/risingwave/relation.py
+++ b/dbt/adapters/risingwave/relation.py
@@ -30,6 +30,7 @@ class RisingWaveRelationType(StrEnum):
     Source = "source"
     Sink = "sink"
     Connection = "connection"
+    Subscription = "subscription"
 
 
 @dataclass(frozen=True, eq=False, repr=False)

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -51,7 +51,7 @@
       from rw_relations
       join rw_schemas on schema_id = rw_schemas.id
       where rw_schemas.name not in ('rw_catalog', 'information_schema', 'pg_catalog')
-        and relation_type in ('table', 'view', 'source', 'sink', 'materialized view', 'index')
+        and relation_type in ('table', 'view', 'source', 'sink', 'subscription', 'materialized view', 'index')
         and rw_schemas.name = '{{ schema_relation.schema }}'
     ),
     rw_schema_functions as (
@@ -202,6 +202,8 @@
       drop source if exists {{ relation }} cascade
     {% elif relation.type == 'sink' %}
       drop sink if exists {{ relation }} cascade
+    {% elif relation.type == 'subscription' %}
+      drop subscription if exists {{ relation }} cascade
     {% elif relation.type == 'function' %}
       drop function if exists {{ relation }}
     {% endif %}
@@ -294,10 +296,36 @@
     ;
 {%- endmacro %}
 
+{% macro risingwave__create_subscription(relation, sql) -%}
+    {{ risingwave__render_sql_header() }}
+
+    {%- set from_relation = sql | trim -%}
+    {%- if from_relation == "" -%}
+      {{ exceptions.raise_compiler_error("`subscription` materialization requires model SQL that renders to a relation, for example a ref() or source() call.") }}
+    {%- endif -%}
+    {%- set retention = config.get("retention", "1D") -%}
+    {%- set subscription_options = config.get("subscription_options", {}) -%}
+    {%- if subscription_options is none -%}
+      {%- set subscription_options = {} -%}
+    {%- endif -%}
+    {%- if subscription_options is not mapping -%}
+      {{ exceptions.raise_compiler_error("`subscription_options` must be a dictionary of RisingWave CREATE SUBSCRIPTION WITH options.") }}
+    {%- endif -%}
+
+    create subscription if not exists {{ relation }}
+    from {{ from_relation }}
+    with (
+      retention = '{{ retention }}'
+      {%- for key, value in subscription_options.items() -%}
+        , {{ key }} = '{{ value }}'
+      {%- endfor -%}
+    );
+{%- endmacro %}
+
 {% macro risingwave__run_sql(sql) -%}
   {% set contract_config = config.get('contract') %}
   {% if contract_config.enforced %}
-    {{exceptions.warn("Model contracts cannot be enforced for source, table_with_connector and sink")}}
+    {{exceptions.warn("Model contracts cannot be enforced for source, table_with_connector, sink and subscription")}}
   {%- endif %}
   {{ risingwave__render_sql_header() }}
   {{ sql }};

--- a/dbt/include/risingwave/macros/materializations/subscription.sql
+++ b/dbt/include/risingwave/macros/materializations/subscription.sql
@@ -1,0 +1,31 @@
+{% materialization subscription, adapter = "risingwave" %}
+    {%- set identifier = model["alias"] -%}
+    {%- set full_refresh_mode = should_full_refresh() -%}
+    {%- set target_relation = api.Relation.create(
+        identifier=identifier,
+        schema=schema,
+        database=database,
+        type="subscription",
+    ) -%}
+    {%- if target_relation.database -%}
+        {{ adapter.verify_database(target_relation.database) }}
+    {%- endif -%}
+    {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
+
+    {% if full_refresh_mode and old_relation %} {{ adapter.drop_relation(old_relation) }} {% endif %}
+
+    {{ run_hooks(pre_hooks, inside_transaction=False) }}
+    {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+    {% if old_relation is none or (full_refresh_mode and old_relation) %}
+        {% call statement("main") -%}
+            {{ risingwave__create_subscription(target_relation, sql) }}
+        {%- endcall %}
+    {% else %} {{ risingwave__execute_no_op(target_relation) }}
+    {% endif %}
+
+    {{ run_hooks(post_hooks, inside_transaction=False) }}
+    {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+    {{ return({"relations": [target_relation]}) }}
+{% endmaterialization %}

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This directory contains the adapter-specific documentation that used to be mixed
 
 ## Guides
 
-- [configuration.md](configuration.md): profile settings, model configuration, and sink options
+- [configuration.md](configuration.md): profile settings, model configuration, sink options, and subscriptions
 - [functions.md](functions.md): first-version RisingWave function support and its limits
 - [zero-downtime-rebuilds.md](zero-downtime-rebuilds.md): zero-downtime rebuild flow for materialized views and views
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,6 +175,51 @@ Caveat:
 
 - RisingWave `WAIT` waits for all background creating jobs, not only the job started by the current dbt model. If other background DDL is running in the same cluster, the dbt node may wait on that work too.
 
+### Subscriptions for Cross-Database MVs
+
+Use `materialized='subscription'` to create a RisingWave subscription in the active dbt target database. This is useful for keeping the upstream log store available for cross-database materialized views managed from another target database.
+
+In the upstream dbt project, create the table or materialized view and a subscription model that references it with `ref()`:
+
+```sql
+{{ config(
+    materialized='subscription',
+    retention='1D'
+) }}
+
+{{ ref('events') }}
+```
+
+The subscription model SQL must render to the table or materialized view being subscribed. Prefer `ref()` so dbt records the dependency and builds the upstream relation first.
+
+In the downstream dbt project, declare the upstream relation as a dbt source so the cross-database reference is tracked in lineage and can vary by environment:
+
+```yaml
+sources:
+  - name: upstream
+    database: upstream_db
+    schema: public
+    tables:
+      - name: events
+```
+
+Then create the downstream materialized view from a dbt target connected to the downstream database:
+
+```sql
+select *
+from {{ source('upstream', 'events') }}
+```
+
+The materialization accepts:
+
+| Option | Description |
+| --- | --- |
+| `schema` | Standard dbt model schema. The subscription is created in this schema. Defaults to the active target schema. |
+| `retention` | Retention value for `WITH (retention = ...)`. Defaults to `1D`. |
+| `subscription_options` | Extra `WITH` options rendered as `key = 'value'`. |
+
+The subscription materialization intentionally does not switch databases. RisingWave creates subscriptions in the current database, so the correct ownership model is to run subscription models with an upstream dbt target/profile and run downstream cross-database MVs with a downstream target/profile. Use dbt's standard `schema` model config when the subscription should live outside the target schema.
+
 ### Index Configuration Changes
 
 `materialized_view`, `table`, and `table_with_connector` support dbt's `on_configuration_change` behavior for index changes.

--- a/tests/e2e/subscriptions/dbt_project.yml
+++ b/tests/e2e/subscriptions/dbt_project.yml
@@ -1,0 +1,9 @@
+name: dbt_risingwave_subscriptions
+version: "1.0"
+config-version: 2
+
+profile: dbt_risingwave_subscriptions
+
+model-paths: ["models"]
+test-paths: ["tests"]
+macro-paths: ["macros"]

--- a/tests/e2e/subscriptions/macros/prepare_subscription_downstream_database.sql
+++ b/tests/e2e/subscriptions/macros/prepare_subscription_downstream_database.sql
@@ -1,0 +1,4 @@
+{% macro prepare_subscription_downstream_database() %}
+  {% do run_query("drop database if exists dbt_subscription_downstream") %}
+  {% do run_query("create database dbt_subscription_downstream") %}
+{% endmacro %}

--- a/tests/e2e/subscriptions/models/downstream_events_mv.sql
+++ b/tests/e2e/subscriptions/models/downstream_events_mv.sql
@@ -1,0 +1,7 @@
+{{ config(
+    materialized='materialized_view',
+    tags=['downstream']
+) }}
+
+select count(*) as event_count
+from {{ source('upstream', 'subscription_events') }}

--- a/tests/e2e/subscriptions/models/sources.yml
+++ b/tests/e2e/subscriptions/models/sources.yml
@@ -1,0 +1,8 @@
+version: 2
+
+sources:
+  - name: upstream
+    database: dev
+    schema: public
+    tables:
+      - name: subscription_events

--- a/tests/e2e/subscriptions/models/subscription_events.sql
+++ b/tests/e2e/subscriptions/models/subscription_events.sql
@@ -1,0 +1,8 @@
+{{ config(
+    materialized='table',
+    tags=['upstream']
+) }}
+
+select 1 as id, 'alpha' as payload
+union all
+select 2 as id, 'beta' as payload

--- a/tests/e2e/subscriptions/models/upstream_events_subscription.sql
+++ b/tests/e2e/subscriptions/models/upstream_events_subscription.sql
@@ -1,0 +1,7 @@
+{{ config(
+    materialized='subscription',
+    retention='1D',
+    tags=['upstream']
+) }}
+
+{{ ref('subscription_events') }}

--- a/tests/e2e/subscriptions/tests/assert_downstream_cross_database_mv.sql
+++ b/tests/e2e/subscriptions/tests/assert_downstream_cross_database_mv.sql
@@ -1,0 +1,6 @@
+{{ config(tags=['downstream']) }}
+
+-- depends_on: {{ ref('downstream_events_mv') }}
+
+select 'downstream cross-database MV should read upstream subscription source rows' as failure
+where (select event_count from {{ ref('downstream_events_mv') }}) != 2

--- a/tests/e2e/subscriptions/tests/assert_subscription_materialization.sql
+++ b/tests/e2e/subscriptions/tests/assert_subscription_materialization.sql
@@ -1,0 +1,13 @@
+{{ config(tags=['upstream']) }}
+
+-- depends_on: {{ ref('upstream_events_subscription') }}
+
+select 'upstream_events_subscription must be a subscription' as failure
+where not exists (
+    select 1
+    from rw_catalog.rw_relations
+    join rw_catalog.rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'upstream_events_subscription'
+      and rw_relations.relation_type = 'subscription'
+)

--- a/tests/unit/test_materialization_relation_lookup.py
+++ b/tests/unit/test_materialization_relation_lookup.py
@@ -9,11 +9,27 @@ MATERIALIZATION_DIR = (
     / "macros"
     / "materializations"
 )
+ADAPTER_MACROS = MATERIALIZATION_DIR.parent / "adapters.sql"
 
 
 def test_connector_materializations_use_catalog_relation_lookup():
-    for filename in ("table_with_connector.sql", "sink.sql", "source.sql"):
+    for filename in ("table_with_connector.sql", "sink.sql", "source.sql", "subscription.sql"):
         materialization = (MATERIALIZATION_DIR / filename).read_text()
 
         assert "risingwave__get_relation_without_caching(target_relation)" in materialization
         assert "adapter.get_relation" not in materialization
+
+
+def test_subscription_materialization_stays_in_current_database():
+    materialization = (MATERIALIZATION_DIR / "subscription.sql").read_text()
+    adapter_macros = ADAPTER_MACROS.read_text()
+
+    assert "set database" not in materialization.lower()
+    assert "set database" not in adapter_macros.lower()
+    assert "risingwave__create_subscription(target_relation, sql)" in materialization
+    assert "sql | trim" in adapter_macros
+    assert 'config.get("subscription_source"' not in adapter_macros
+    assert 'config.get("relation"' not in adapter_macros
+    assert 'config.get("from"' not in adapter_macros
+    assert 'config.get("from_name"' not in adapter_macros
+    assert 'config.get("from_schema"' not in adapter_macros


### PR DESCRIPTION
## Summary
- add a `subscription` materialization that creates RisingWave subscriptions in the active target database from `source_schema` / `source_table`
- add catalog/drop support, docs, and README/doc index entries for subscription usage
- add unit coverage, a subscription e2e fixture, and a CI job for the new fixture

## Verification
- `dbt-env/bin/python -m pytest tests/unit`
- `.venv-validate/bin/dbt --profile dbt_risingwave_functions build --no-partial-parse --project-dir tests/e2e/subscriptions --target dev`
- `psql -h localhost -p 4566 -d dev -U root -Atc "show create subscription public.upstream_events_subscription;"`
- `.venv-validate/bin/dbt --profile dbt_risingwave_functions docs generate --no-partial-parse --project-dir tests/e2e/subscriptions --target dev`
- `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/ci.yml\")"`
- `git diff --check && git diff --cached --check`