### PR TITLE
Support grants for connector materializations

### DIFF
--- a/dbt/include/risingwave/macros/materializations/grants.sql
+++ b/dbt/include/risingwave/macros/materializations/grants.sql
@@ -26,6 +26,9 @@
     grant {{ privilege }} on
     {%- if relation.type == 'materialized_view' %} materialized view
     {%- elif relation.type == 'view' %} view
+    {%- elif relation.type == 'source' %} source
+    {%- elif relation.type == 'sink' %} sink
+    {%- elif relation.type == 'subscription' %} subscription
     {%- else %} table
     {%- endif %}
     {{ relation.render() }} to {{ grantees | join(', ') }}
@@ -36,6 +39,9 @@
     revoke {{ privilege }} on
     {%- if relation.type == 'materialized_view' %} materialized view
     {%- elif relation.type == 'view' %} view
+    {%- elif relation.type == 'source' %} source
+    {%- elif relation.type == 'sink' %} sink
+    {%- elif relation.type == 'subscription' %} subscription
     {%- else %} table
     {%- endif %}
     {{ relation.render() }} from {{ grantees | join(', ') }}

--- a/dbt/include/risingwave/macros/materializations/sink.sql
+++ b/dbt/include/risingwave/macros/materializations/sink.sql
@@ -8,6 +8,7 @@
         type="sink",
     ) -%}
     {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
+    {%- set grant_config = config.get("grants") -%}
 
     {% if full_refresh_mode and old_relation %} {{ adapter.drop_relation(old_relation) }} {% endif %}
 
@@ -24,6 +25,9 @@
         {{ risingwave__wait_for_background_ddl(target_relation, "sink") }}
     {% else %} {{ risingwave__execute_no_op(target_relation) }}
     {% endif %}
+
+    {% set should_revoke = should_revoke(existing_relation=old_relation, full_refresh_mode=full_refresh_mode) %}
+    {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
     {% do persist_docs(target_relation, model) %}
 

--- a/dbt/include/risingwave/macros/materializations/source.sql
+++ b/dbt/include/risingwave/macros/materializations/source.sql
@@ -5,6 +5,7 @@
         identifier=identifier, schema=schema, database=database, type="source"
     ) -%}
     {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
+    {%- set grant_config = config.get("grants") -%}
 
     {% if full_refresh_mode and old_relation %} {{ adapter.drop_relation(old_relation) }} {% endif %}
 
@@ -15,6 +16,9 @@
         {% call statement("main") -%} {{ risingwave__run_sql(sql) }} {%- endcall %}
     {% else %} {{ risingwave__execute_no_op(target_relation) }}
     {% endif %}
+
+    {% set should_revoke = should_revoke(existing_relation=old_relation, full_refresh_mode=full_refresh_mode) %}
+    {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
     {% do persist_docs(target_relation, model) %}
 

--- a/dbt/include/risingwave/macros/materializations/subscription.sql
+++ b/dbt/include/risingwave/macros/materializations/subscription.sql
@@ -11,6 +11,7 @@
         {{ adapter.verify_database(target_relation.database) }}
     {%- endif -%}
     {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
+    {%- set grant_config = config.get("grants") -%}
 
     {% if full_refresh_mode and old_relation %} {{ adapter.drop_relation(old_relation) }} {% endif %}
 
@@ -23,6 +24,9 @@
         {%- endcall %}
     {% else %} {{ risingwave__execute_no_op(target_relation) }}
     {% endif %}
+
+    {% set should_revoke = should_revoke(existing_relation=old_relation, full_refresh_mode=full_refresh_mode) %}
+    {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
     {{ run_hooks(post_hooks, inside_transaction=False) }}
     {{ run_hooks(post_hooks, inside_transaction=True) }}

--- a/dbt/include/risingwave/macros/materializations/table_with_connector.sql
+++ b/dbt/include/risingwave/macros/materializations/table_with_connector.sql
@@ -5,6 +5,7 @@
         identifier=identifier, schema=schema, database=database, type="table"
     ) -%}
     {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
+    {%- set grant_config = config.get("grants") -%}
 
     {% if full_refresh_mode and old_relation %} {{ adapter.drop_relation(old_relation) }} {% endif %}
 
@@ -24,6 +25,9 @@
             {% do store_raw_result(name="main", message="ALTER_TABLE", code="ALTER_TABLE", rows_affected="-1") %}
         {% endif %}
     {% endif %}
+
+    {% set should_revoke = should_revoke(existing_relation=old_relation, full_refresh_mode=full_refresh_mode) %}
+    {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
     {% do persist_docs(target_relation, model) %}
 

--- a/tests/e2e/grants_docs_schema/models/docs_base_subscription.sql
+++ b/tests/e2e/grants_docs_schema/models/docs_base_subscription.sql
@@ -1,0 +1,3 @@
+{{ config(materialized='subscription', retention='1D') }}
+
+{{ ref('docs_base_mv') }}

--- a/tests/e2e/grants_docs_schema/models/docs_blackhole_sink.sql
+++ b/tests/e2e/grants_docs_schema/models/docs_blackhole_sink.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized='sink',
+    connector='blackhole',
+    connector_parameters={
+      'type': 'append-only',
+      'force_append_only': 'true'
+    }
+) }}
+
+select
+    id,
+    payload
+from {{ ref('docs_base_table') }}

--- a/tests/e2e/grants_docs_schema/models/docs_connector_table.sql
+++ b/tests/e2e/grants_docs_schema/models/docs_connector_table.sql
@@ -1,0 +1,8 @@
+{{ config(materialized='table_with_connector') }}
+
+create table {{ this }} (
+    id int,
+    payload varchar
+) with (
+    appendonly = 'true'
+)

--- a/tests/e2e/grants_docs_schema/models/docs_datagen_source.sql
+++ b/tests/e2e/grants_docs_schema/models/docs_datagen_source.sql
@@ -1,0 +1,16 @@
+{{ config(materialized='source') }}
+
+create source {{ this }} (
+    id integer,
+    payload varchar
+)
+with (
+    connector = 'datagen',
+    fields.id.kind = 'sequence',
+    fields.id.start = '1',
+    fields.id.end = '3',
+    fields.payload.kind = 'random',
+    fields.payload.length = '8',
+    fields.payload.seed = '7',
+    datagen.rows.per.second = '1'
+)

--- a/tests/e2e/grants_docs_schema/tests/assert_grants_docs_schema.sql
+++ b/tests/e2e/grants_docs_schema/tests/assert_grants_docs_schema.sql
@@ -15,7 +15,15 @@ target_relations as (
         rw_relations.acl
     from rw_catalog.rw_relations
     join target_schema on rw_relations.schema_id = target_schema.id
-    where rw_relations.name in ('docs_base_table', 'docs_base_view', 'docs_base_mv')
+    where rw_relations.name in (
+        'docs_base_table',
+        'docs_base_view',
+        'docs_base_mv',
+        'docs_connector_table',
+        'docs_datagen_source',
+        'docs_blackhole_sink',
+        'docs_base_subscription'
+    )
 ),
 relation_comments as (
     select
@@ -77,6 +85,46 @@ where not exists (
 
 union all
 
+select 'docs_connector_table must be a table' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_connector_table'
+      and relation_type = 'table'
+)
+
+union all
+
+select 'docs_datagen_source must be a source' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_datagen_source'
+      and relation_type = 'source'
+)
+
+union all
+
+select 'docs_blackhole_sink must be a sink' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_blackhole_sink'
+      and relation_type = 'sink'
+)
+
+union all
+
+select 'docs_base_subscription must be a subscription' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_base_subscription'
+      and relation_type = 'subscription'
+)
+
+union all
+
 select 'docs_base_table grant missing' as failure
 where not exists (
     select 1
@@ -102,6 +150,46 @@ where not exists (
     select 1
     from target_relations
     where name = 'docs_base_mv'
+      and array_to_string(acl, ',') like '%dbt_e2e_gds_grantee=r/%'
+)
+
+union all
+
+select 'docs_connector_table grant missing' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_connector_table'
+      and array_to_string(acl, ',') like '%dbt_e2e_gds_grantee=r/%'
+)
+
+union all
+
+select 'docs_datagen_source grant missing' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_datagen_source'
+      and array_to_string(acl, ',') like '%dbt_e2e_gds_grantee=r/%'
+)
+
+union all
+
+select 'docs_blackhole_sink grant missing' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_blackhole_sink'
+      and array_to_string(acl, ',') like '%dbt_e2e_gds_grantee=r/%'
+)
+
+union all
+
+select 'docs_base_subscription grant missing' as failure
+where not exists (
+    select 1
+    from target_relations
+    where name = 'docs_base_subscription'
       and array_to_string(acl, ',') like '%dbt_e2e_gds_grantee=r/%'
 )
 

--- a/tests/unit/test_materialization_relation_lookup.py
+++ b/tests/unit/test_materialization_relation_lookup.py
@@ -20,6 +20,15 @@ def test_connector_materializations_use_catalog_relation_lookup():
         assert "adapter.get_relation" not in materialization
 
 
+def test_connector_materializations_apply_grants():
+    for filename in ("table_with_connector.sql", "sink.sql", "source.sql", "subscription.sql"):
+        materialization = (MATERIALIZATION_DIR / filename).read_text()
+
+        assert 'config.get("grants")' in materialization
+        assert "should_revoke(existing_relation=old_relation" in materialization
+        assert "apply_grants(target_relation, grant_config" in materialization
+
+
 def test_subscription_materialization_stays_in_current_database():
     materialization = (MATERIALIZATION_DIR / "subscription.sql").read_text()
     adapter_macros = ADAPTER_MACROS.read_text()


### PR DESCRIPTION
## Summary
- apply dbt grants lifecycle to custom source, table_with_connector, sink, and subscription materializations
- generate GRANT/REVOKE statements with RisingWave object types for source, sink, and subscription relations
- extend grants docs/schema e2e coverage for connector table, datagen source, blackhole sink, and subscription grants

