### PR TITLE
feat: support native RisingWave session model configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Use `schema_authorization` when dbt should create schemas with a specific owner:
 
 See [docs/configuration.md](docs/configuration.md) for model-level and `dbt_project.yml` examples.
 
-### Streaming Parallelism
+### RisingWave Native Model Configs
 
-The adapter supports RisingWave session settings such as `streaming_parallelism`, `streaming_parallelism_for_backfill`, and `streaming_max_parallelism` in both profiles and model configs.
+The adapter supports RisingWave session settings such as `streaming_parallelism`, `streaming_parallelism_for_backfill`, `backfill_rate_limit`, and `enable_index_selection` in profiles and native model configs.
 
 See [docs/configuration.md](docs/configuration.md) for the full configuration matrix.
 

--- a/dbt/adapters/risingwave/connections.py
+++ b/dbt/adapters/risingwave/connections.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import psycopg2
 from dbt.adapters.contracts.connection import Connection
@@ -12,6 +12,23 @@ from dbt.adapters.postgres.connections import (
 logger = AdapterLogger("RisingWave")
 
 
+RISINGWAVE_PROFILE_SESSION_SETTINGS = (
+    "streaming_parallelism",
+    "streaming_parallelism_for_backfill",
+    "streaming_max_parallelism",
+    "enable_serverless_backfill",
+    "backfill_rate_limit",
+    "source_rate_limit",
+    "sink_rate_limit",
+    "streaming_parallelism_for_materialized_view",
+    "streaming_parallelism_for_source",
+    "streaming_parallelism_for_table",
+    "streaming_parallelism_for_sink",
+    "streaming_parallelism_for_index",
+    "enable_index_selection",
+)
+
+
 @dataclass
 class RisingWaveCredentials(PostgresCredentials):
     """
@@ -19,11 +36,19 @@ class RisingWaveCredentials(PostgresCredentials):
     & https://github.com/dbt-labs/dbt-core/blob/b2ea2b8b256e5db1da0b712dfedd7973e1e50a37/plugins/postgres/dbt/adapters/postgres/connections.py#L20
     """
 
-    # todo(siwei): append more config here
-    streaming_parallelism: Optional[int] = None
-    streaming_parallelism_for_backfill: Optional[int] = None
-    streaming_max_parallelism: Optional[int] = None
+    streaming_parallelism: Optional[Any] = None
+    streaming_parallelism_for_backfill: Optional[Any] = None
+    streaming_max_parallelism: Optional[Any] = None
     enable_serverless_backfill: Optional[bool] = None
+    backfill_rate_limit: Optional[int] = None
+    source_rate_limit: Optional[int] = None
+    sink_rate_limit: Optional[int] = None
+    streaming_parallelism_for_materialized_view: Optional[Any] = None
+    streaming_parallelism_for_source: Optional[Any] = None
+    streaming_parallelism_for_table: Optional[Any] = None
+    streaming_parallelism_for_sink: Optional[Any] = None
+    streaming_parallelism_for_index: Optional[Any] = None
+    enable_index_selection: Optional[bool] = None
 
     @property
     def type(self):
@@ -148,20 +173,26 @@ class RisingWaveConnectionManager(PostgresConnectionManager):
         cursor = handle.cursor()
         try:
             cursor.execute("SET RW_IMPLICIT_FLUSH TO true")
-            session_settings = (
-                ("streaming_parallelism", credentials.streaming_parallelism),
-                (
-                    "streaming_parallelism_for_backfill",
-                    credentials.streaming_parallelism_for_backfill,
-                ),
-                ("streaming_max_parallelism", credentials.streaming_max_parallelism),
-                ("enable_serverless_backfill", credentials.enable_serverless_backfill),
-            )
-            for setting, value in session_settings:
+            for setting in RISINGWAVE_PROFILE_SESSION_SETTINGS:
+                value = getattr(credentials, setting, None)
                 if value is not None:
-                    cursor.execute(f"SET {setting} = {value}")
+                    cursor.execute(
+                        f"SET {setting} = {RisingWaveConnectionManager._format_session_value(value)}"
+                    )
         finally:
             cursor.close()
+
+    @staticmethod
+    def _format_session_value(value: Any) -> str:
+        if isinstance(value, bool):
+            return str(value).lower()
+        if isinstance(value, (int, float)):
+            return str(value)
+
+        value_str = str(value)
+        if value_str.lower() in {"default", "adaptive"}:
+            return value_str
+        return "'" + value_str.replace("'", "''") + "'"
 
     def cancel(self, connection: Connection):
         # index here references the column order in processlist output:

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -2,6 +2,39 @@
 -- But materialize verison includes 'index' type.
 -- Here we only query table, view, materialized view and source. (without index and SINK)
 
+{% macro risingwave__render_session_config_value(value) -%}
+  {%- if value is boolean -%}
+    {{- value | lower -}}
+  {%- elif value is number -%}
+    {{- value -}}
+  {%- else -%}
+    {%- set value_str = value | string -%}
+    {%- if value_str | lower in ["default", "adaptive"] -%}
+      {{- value_str -}}
+    {%- else -%}
+      '{{- value_str | replace("'", "''") -}}'
+    {%- endif -%}
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro risingwave__native_model_session_settings() -%}
+  {{ return([
+    "streaming_parallelism",
+    "streaming_parallelism_for_backfill",
+    "streaming_max_parallelism",
+    "enable_serverless_backfill",
+    "backfill_rate_limit",
+    "source_rate_limit",
+    "sink_rate_limit",
+    "streaming_parallelism_for_materialized_view",
+    "streaming_parallelism_for_source",
+    "streaming_parallelism_for_table",
+    "streaming_parallelism_for_sink",
+    "streaming_parallelism_for_index",
+    "enable_index_selection",
+  ]) }}
+{%- endmacro %}
+
 {% macro risingwave__render_sql_header() -%}
   {%- set header_parts = [] -%}
   {%- set user_header = config.get("sql_header", none) -%}
@@ -9,30 +42,17 @@
     {%- do header_parts.append(user_header) -%}
   {%- endif -%}
 
-  {%- set background_ddl = config.get("background_ddl", false) -%}
-  {%- if background_ddl -%}
-    {%- do header_parts.append("set background_ddl = true;") -%}
+  {%- set background_ddl = config.get("background_ddl", none) -%}
+  {%- if background_ddl is not none -%}
+    {%- do header_parts.append("set background_ddl = " ~ risingwave__render_session_config_value(background_ddl) ~ ";") -%}
   {%- endif -%}
 
-  {%- set streaming_parallelism = config.get("streaming_parallelism", none) -%}
-  {%- if streaming_parallelism is not none -%}
-    {%- do header_parts.append("set streaming_parallelism = " ~ streaming_parallelism ~ ";") -%}
-  {%- endif -%}
-
-  {%- set streaming_parallelism_for_backfill = config.get("streaming_parallelism_for_backfill", none) -%}
-  {%- if streaming_parallelism_for_backfill is not none -%}
-    {%- do header_parts.append("set streaming_parallelism_for_backfill = " ~ streaming_parallelism_for_backfill ~ ";") -%}
-  {%- endif -%}
-
-  {%- set streaming_max_parallelism = config.get("streaming_max_parallelism", none) -%}
-  {%- if streaming_max_parallelism is not none -%}
-    {%- do header_parts.append("set streaming_max_parallelism = " ~ streaming_max_parallelism ~ ";") -%}
-  {%- endif -%}
-
-  {%- set enable_serverless_backfill = config.get("enable_serverless_backfill", none) -%}
-  {%- if enable_serverless_backfill is not none -%}
-    {%- do header_parts.append("set enable_serverless_backfill = " ~ enable_serverless_backfill | lower ~ ";") -%}
-  {%- endif -%}
+  {%- for setting in risingwave__native_model_session_settings() -%}
+    {%- set value = config.get(setting, none) -%}
+    {%- if value is not none -%}
+      {%- do header_parts.append("set " ~ setting ~ " = " ~ risingwave__render_session_config_value(value) ~ ";") -%}
+    {%- endif -%}
+  {%- endfor -%}
 
   {{- header_parts | join("\n") -}}
 {%- endmacro %}
@@ -164,6 +184,8 @@
 {% endmacro %}
 
 {% macro risingwave__get_create_index_sql(relation, index_dict) -%}
+  {{ risingwave__render_sql_header() }}
+
   {%- set index_config = adapter.parse_index({"columns": index_dict.get("columns", [])}) -%}
   {%- set comma_separated_columns = ", ".join(index_config.columns) -%}
   {%- set index_name = risingwave__get_index_name(relation.identifier, index_config.columns) -%}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,9 @@ default:
       streaming_parallelism_for_backfill: 2
       streaming_max_parallelism: 8
       enable_serverless_backfill: true
+      backfill_rate_limit: 1000
+      streaming_parallelism_for_materialized_view: 4
+      enable_index_selection: true
   target: dev
 ```
 
@@ -48,6 +51,17 @@ Supported adapter-specific profile keys:
 | `streaming_parallelism_for_backfill` | Sets `SET streaming_parallelism_for_backfill = ...` for the session. |
 | `streaming_max_parallelism` | Sets `SET streaming_max_parallelism = ...` for the session. |
 | `enable_serverless_backfill` | Sets `SET enable_serverless_backfill = true/false` for the session. |
+| `backfill_rate_limit` | Sets `SET backfill_rate_limit = ...` for the session. |
+| `source_rate_limit` | Sets `SET source_rate_limit = ...` for the session. |
+| `sink_rate_limit` | Sets `SET sink_rate_limit = ...` for the session. |
+| `streaming_parallelism_for_materialized_view` | Sets `SET streaming_parallelism_for_materialized_view = ...` for the session. |
+| `streaming_parallelism_for_source` | Sets `SET streaming_parallelism_for_source = ...` for the session. |
+| `streaming_parallelism_for_table` | Sets `SET streaming_parallelism_for_table = ...` for the session. |
+| `streaming_parallelism_for_sink` | Sets `SET streaming_parallelism_for_sink = ...` for the session. |
+| `streaming_parallelism_for_index` | Sets `SET streaming_parallelism_for_index = ...` for the session. |
+| `enable_index_selection` | Sets `SET enable_index_selection = true/false` for the session. |
+
+`background_ddl` is supported as a model config rather than a profile key because the adapter must issue `WAIT` after background DDL submissions to preserve dbt's dependency semantics.
 
 ## Model Configuration
 
@@ -94,23 +108,53 @@ from ...
 
 The adapter appends its own RisingWave session settings after the custom header when those configs are present.
 
-### Streaming Parallelism Per Model
+### Native Session Model Configs
 
-You can override the session-level streaming settings for an individual model:
+You can override supported RisingWave session settings for an individual model. These configs are emitted in the SQL header before the model DDL runs:
 
 ```sql
 {{ config(
     materialized='materialized_view',
     streaming_parallelism=2,
     streaming_parallelism_for_backfill=2,
-    streaming_max_parallelism=8
+    streaming_max_parallelism=8,
+    streaming_parallelism_for_materialized_view=4,
+    backfill_rate_limit=1000,
+    enable_index_selection=true
 ) }}
 
 select *
 from {{ ref('events') }}
 ```
 
-These values are emitted in the SQL header before the model DDL runs.
+Supported model configs:
+
+| Key | Description |
+| --- | --- |
+| `streaming_parallelism` | Sets the initial streaming parallelism for streaming jobs. |
+| `streaming_parallelism_for_backfill` | Sets streaming parallelism for backfill. |
+| `streaming_max_parallelism` | Sets the maximum future streaming parallelism. |
+| `streaming_parallelism_for_materialized_view` | Sets materialized-view-specific streaming parallelism. |
+| `streaming_parallelism_for_source` | Sets source-specific streaming parallelism. |
+| `streaming_parallelism_for_table` | Sets table-specific streaming parallelism. |
+| `streaming_parallelism_for_sink` | Sets sink-specific streaming parallelism. |
+| `streaming_parallelism_for_index` | Sets index-specific streaming parallelism. |
+| `backfill_rate_limit` | Sets the backfill rate limit for MV/source/sink backfilling. |
+| `source_rate_limit` | Sets the source rate limit. |
+| `sink_rate_limit` | Sets the sink rate limit. |
+| `enable_serverless_backfill` | Enables or disables serverless backfill for streaming queries. |
+| `background_ddl` | Runs supported DDL in the background and waits before dbt continues. |
+| `enable_index_selection` | Enables or disables index selection while planning the model SQL. |
+
+These configs can also be set globally in `dbt_project.yml`:
+
+```yaml
+models:
+  my_project:
+    +streaming_parallelism_for_backfill: 2
+    +backfill_rate_limit: 1000
+    +enable_index_selection: true
+```
 
 ### Serverless Backfill
 

--- a/tests/unit/test_materialization_relation_lookup.py
+++ b/tests/unit/test_materialization_relation_lookup.py
@@ -1,4 +1,7 @@
+import importlib.util
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 MATERIALIZATION_DIR = (
@@ -10,6 +13,23 @@ MATERIALIZATION_DIR = (
     / "materializations"
 )
 ADAPTER_MACROS = MATERIALIZATION_DIR.parent / "adapters.sql"
+CONNECTIONS = MATERIALIZATION_DIR.parents[3] / "adapters" / "risingwave" / "connections.py"
+
+NATIVE_MODEL_SESSION_SETTINGS = {
+    "streaming_parallelism",
+    "streaming_parallelism_for_backfill",
+    "streaming_max_parallelism",
+    "enable_serverless_backfill",
+    "backfill_rate_limit",
+    "source_rate_limit",
+    "sink_rate_limit",
+    "streaming_parallelism_for_materialized_view",
+    "streaming_parallelism_for_source",
+    "streaming_parallelism_for_table",
+    "streaming_parallelism_for_sink",
+    "streaming_parallelism_for_index",
+    "enable_index_selection",
+}
 
 
 def test_connector_materializations_use_catalog_relation_lookup():
@@ -42,3 +62,73 @@ def test_subscription_materialization_stays_in_current_database():
     assert 'config.get("from"' not in adapter_macros
     assert 'config.get("from_name"' not in adapter_macros
     assert 'config.get("from_schema"' not in adapter_macros
+
+
+def test_native_session_model_configs_are_allowlisted():
+    adapter_macros = ADAPTER_MACROS.read_text()
+
+    for setting in NATIVE_MODEL_SESSION_SETTINGS:
+        assert f'"{setting}"' in adapter_macros
+
+    assert 'config.get("background_ddl", none)' in adapter_macros
+    assert "risingwave__native_model_session_settings()" in adapter_macros
+    assert "set database" not in adapter_macros.lower()
+
+
+def test_profile_session_settings_are_allowlisted():
+    connections = load_local_connections_module()
+
+    assert set(connections.RISINGWAVE_PROFILE_SESSION_SETTINGS) == NATIVE_MODEL_SESSION_SETTINGS
+    assert "background_ddl" not in connections.RISINGWAVE_PROFILE_SESSION_SETTINGS
+
+
+def test_profile_session_settings_render_safe_set_statements():
+    connections = load_local_connections_module()
+
+    class FakeCursor:
+        def __init__(self):
+            self.statements = []
+            self.closed = False
+
+        def execute(self, sql):
+            self.statements.append(sql)
+
+        def close(self):
+            self.closed = True
+
+    class FakeHandle:
+        def __init__(self):
+            self.cursor_obj = FakeCursor()
+
+        def cursor(self):
+            return self.cursor_obj
+
+    handle = FakeHandle()
+    credentials = SimpleNamespace(
+        streaming_parallelism_for_materialized_view="bounded(16)",
+        streaming_parallelism_for_source="ratio(0.5)",
+        backfill_rate_limit=1000,
+        enable_serverless_backfill=True,
+        enable_index_selection=False,
+    )
+
+    connections.RisingWaveConnectionManager._configure_session(handle, credentials)
+
+    assert handle.cursor_obj.closed
+    assert handle.cursor_obj.statements == [
+        "SET RW_IMPLICIT_FLUSH TO true",
+        "SET enable_serverless_backfill = true",
+        "SET backfill_rate_limit = 1000",
+        "SET streaming_parallelism_for_materialized_view = 'bounded(16)'",
+        "SET streaming_parallelism_for_source = 'ratio(0.5)'",
+        "SET enable_index_selection = false",
+    ]
+
+
+def load_local_connections_module():
+    module_name = "local_risingwave_connections"
+    spec = importlib.util.spec_from_file_location(module_name, CONNECTIONS)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module


### PR DESCRIPTION
## Summary
- add allowlisted RisingWave profile/session settings for backfill, rate limit, parallelism, and enable_index_selection
- render native model configs into SQL headers, including index creation, while keeping background_ddl model-only for WAIT semantics
- document the supported config matrix and add focused unit coverage

## Tests
- dbt-env/bin/pytest tests/unit/test_materialization_relation_lookup.py -q
- dbt-env/bin/python -m py_compile dbt/adapters/risingwave/connections.py tests/unit/test_materialization_relation_lookup.py
- dbt-env/bin/python Jinja parse check for dbt/include/risingwave/macros/adapters.sql
- git diff --check