### PR TITLE
feat: add secret materialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -735,6 +735,8 @@ jobs:
     services:
       risingwave:
         image: ghcr.io/risingwavelabs/risingwave:latest # RW version should be manually updated until a released version is compatiable with this adapter.
+        env:
+          RW_SECRET_STORE_PRIVATE_KEY_HEX: 0123456789abcdef0123456789abcdef
         ports:
           - 4566:4566
         options: >-

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ from {{ ref('events') }}
 | `view` | Creates a view from the model query. |
 | `incremental` | Batch-style incremental updates for tables. Prefer `materialized_view` when a streaming MV fits the workload. |
 | `connection` | Runs a full `CREATE CONNECTION` statement supplied by the model SQL. |
+| `secret` | Runs a full `CREATE SECRET` statement supplied by the model SQL. |
 | `source` | Runs a full `CREATE SOURCE` statement supplied by the model SQL. |
 | `table_with_connector` | Runs a full `CREATE TABLE ... WITH (...)` statement supplied by the model SQL. Supports explicit additive `ALTER TABLE ADD COLUMN` changes through `on_schema_change='append_new_columns'`. |
 | `sink` | Creates a sink, either from adapter configs or from a full SQL statement. |

--- a/dbt/adapters/risingwave/relation.py
+++ b/dbt/adapters/risingwave/relation.py
@@ -30,6 +30,7 @@ class RisingWaveRelationType(StrEnum):
     Source = "source"
     Sink = "sink"
     Connection = "connection"
+    Secret = "secret"
     Subscription = "subscription"
 
 

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -224,6 +224,8 @@
       drop source if exists {{ relation }} cascade
     {% elif relation.type == 'sink' %}
       drop sink if exists {{ relation }} cascade
+    {% elif relation.type == 'secret' %}
+      drop secret if exists {{ relation }} cascade
     {% elif relation.type == 'subscription' %}
       drop subscription if exists {{ relation }} cascade
     {% elif relation.type == 'function' %}

--- a/dbt/include/risingwave/macros/materializations/grants.sql
+++ b/dbt/include/risingwave/macros/materializations/grants.sql
@@ -3,6 +3,24 @@
    for non-table objects. These overrides add the correct ON <type> clause. #}
 
 {% macro risingwave__get_show_grant_sql(relation) %}
+  {% if relation.type == 'secret' %}
+  with relation_acl as (
+    select
+      unnest(rw_secrets.acl) as acl_entry
+    from rw_catalog.rw_secrets
+    join rw_catalog.rw_schemas on rw_secrets.schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ relation.schema }}'
+      and rw_secrets.name = '{{ relation.identifier }}'
+  )
+  select
+    split_part(acl_entry, '=', 1) as grantee,
+    case
+      when split_part(split_part(acl_entry, '=', 2), '/', 1) like '%U%' then 'usage'
+    end as privilege_type
+  from relation_acl
+  where split_part(acl_entry, '=', 1) not in ('root', 'rwadmin', 'postgres')
+    and split_part(split_part(acl_entry, '=', 2), '/', 1) like '%U%'
+  {% else %}
   with relation_acl as (
     select
       unnest(rw_relations.acl) as acl_entry
@@ -20,6 +38,7 @@
   from relation_acl
   where split_part(acl_entry, '=', 1) not in ('root', 'rwadmin', 'postgres')
     and split_part(split_part(acl_entry, '=', 2), '/', 1) like '%r%'
+  {% endif %}
 {% endmacro %}
 
 {%- macro risingwave__get_grant_sql(relation, privilege, grantees) -%}
@@ -28,6 +47,7 @@
     {%- elif relation.type == 'view' %} view
     {%- elif relation.type == 'source' %} source
     {%- elif relation.type == 'sink' %} sink
+    {%- elif relation.type == 'secret' %} secret
     {%- elif relation.type == 'subscription' %} subscription
     {%- else %} table
     {%- endif %}
@@ -41,6 +61,7 @@
     {%- elif relation.type == 'view' %} view
     {%- elif relation.type == 'source' %} source
     {%- elif relation.type == 'sink' %} sink
+    {%- elif relation.type == 'secret' %} secret
     {%- elif relation.type == 'subscription' %} subscription
     {%- else %} table
     {%- endif %}

--- a/dbt/include/risingwave/macros/materializations/secret.sql
+++ b/dbt/include/risingwave/macros/materializations/secret.sql
@@ -1,0 +1,54 @@
+{% materialization secret, adapter='risingwave' %}
+  {%- set identifier = model['alias'] -%}
+  {%- set full_refresh_mode = should_full_refresh() -%}
+  {%- set target_relation = api.Relation.create(
+      identifier=identifier,
+      schema=schema,
+      database=database,
+      type='secret'
+  ) -%}
+  {%- set existing_secret = false -%}
+  {%- set old_relation = none -%}
+  {%- set grant_config = config.get("grants") -%}
+
+  {% if execute %}
+    {% set secret_exists_sql %}
+      select 1
+      from rw_catalog.rw_secrets s
+      join rw_catalog.rw_schemas sc on s.schema_id = sc.id
+      where sc.name = '{{ schema }}'
+        and s.name = '{{ identifier }}'
+      limit 1
+    {% endset %}
+    {% set existing_secret_result = run_query(secret_exists_sql) %}
+    {% if existing_secret_result is not none and (existing_secret_result.rows | length) > 0 %}
+      {%- set existing_secret = true -%}
+      {%- set old_relation = target_relation -%}
+    {% endif %}
+  {% endif %}
+
+  {% if full_refresh_mode and existing_secret %}
+    {% call statement('drop_secret') -%}
+      drop secret if exists {{ target_relation }} cascade
+    {%- endcall %}
+  {% endif %}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% if not existing_secret or (full_refresh_mode and existing_secret) %}
+    {% call statement('main') -%}
+      {{ risingwave__run_sql(sql) }}
+    {%- endcall %}
+  {% else %}
+    {{ risingwave__execute_no_op(target_relation) }}
+  {% endif %}
+
+  {% set should_revoke = should_revoke(existing_relation=old_relation, full_refresh_mode=full_refresh_mode) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  {{ return({'relations': [target_relation]}) }}
+{% endmaterialization %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -219,6 +219,24 @@ Caveat:
 
 - RisingWave `WAIT` waits for all background creating jobs, not only the job started by the current dbt model. If other background DDL is running in the same cluster, the dbt node may wait on that work too.
 
+### Secrets
+
+Use `materialized='secret'` to manage a RisingWave secret from a dbt model. The model SQL should be the complete `CREATE SECRET` statement:
+
+```sql
+{{ config(materialized='secret') }}
+
+create secret {{ this.identifier }}
+with (backend = 'meta')
+as '{{ env_var("DBT_RW_KAFKA_PASSWORD") }}'
+```
+
+The materialization checks `rw_catalog.rw_secrets` in the target schema. If the secret already exists, normal `dbt run` leaves it unchanged. `dbt run --full-refresh` drops and recreates the secret from the model SQL.
+
+Secrets support dbt grants with RisingWave's `usage` privilege.
+
+Because dbt compiles model SQL into artifacts, prefer `env_var()` or another external secret source rather than hard-coding sensitive values in the project.
+
 ### Subscriptions for Cross-Database MVs
 
 Use `materialized='subscription'` to create a RisingWave subscription in the active dbt target database. This is useful for keeping the upstream log store available for cross-database materialized views managed from another target database.

--- a/tests/e2e/source_connection/models/api_password_secret.sql
+++ b/tests/e2e/source_connection/models/api_password_secret.sql
@@ -1,0 +1,5 @@
+{{ config(materialized='secret') }}
+
+create secret {{ this.identifier }}
+with (backend = 'meta')
+as '{{ env_var("DBT_RW_E2E_SECRET_VALUE", "dbt-risingwave-secret") }}'

--- a/tests/e2e/source_connection/tests/assert_source_connection_materializations.sql
+++ b/tests/e2e/source_connection/tests/assert_source_connection_materializations.sql
@@ -25,3 +25,25 @@ where (
     from rw_catalog.rw_connections
     where name = 'schema_registry_connection'
 ) != 1
+
+union all
+
+select 'api_password_secret must exist' as failure
+where not exists (
+    select 1
+    from rw_catalog.rw_secrets
+    join rw_catalog.rw_schemas on rw_secrets.schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_secrets.name = 'api_password_secret'
+)
+
+union all
+
+select 'api_password_secret should be unique' as failure
+where (
+    select count(*)
+    from rw_catalog.rw_secrets
+    join rw_catalog.rw_schemas on rw_secrets.schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_secrets.name = 'api_password_secret'
+) != 1

--- a/tests/unit/test_materialization_relation_lookup.py
+++ b/tests/unit/test_materialization_relation_lookup.py
@@ -49,6 +49,30 @@ def test_connector_materializations_apply_grants():
         assert "apply_grants(target_relation, grant_config" in materialization
 
 
+def test_secret_materialization_uses_secret_catalog_lifecycle():
+    materialization = (MATERIALIZATION_DIR / "secret.sql").read_text()
+
+    assert "type='secret'" in materialization
+    assert "rw_catalog.rw_secrets" in materialization
+    assert "rw_catalog.rw_schemas" in materialization
+    assert "drop secret if exists {{ target_relation }} cascade" in materialization
+    assert "risingwave__run_sql(sql)" in materialization
+    assert 'config.get("grants")' in materialization
+    assert "apply_grants(target_relation, grant_config" in materialization
+    assert "adapter.get_relation" not in materialization
+
+
+def test_secret_grants_use_secret_catalog_and_usage_privilege():
+    grants = (MATERIALIZATION_DIR / "grants.sql").read_text()
+    adapter_macros = ADAPTER_MACROS.read_text()
+
+    assert "relation.type == 'secret'" in grants
+    assert "rw_catalog.rw_secrets" in grants
+    assert "then 'usage'" in grants
+    assert "relation.type == 'secret' %} secret" in grants
+    assert "drop secret if exists {{ relation }} cascade" in adapter_macros
+
+
 def test_subscription_materialization_stays_in_current_database():
     materialization = (MATERIALIZATION_DIR / "subscription.sql").read_text()
     adapter_macros = ADAPTER_MACROS.read_text()


### PR DESCRIPTION
## Summary
- add a first-class `secret` materialization that runs model-provided `CREATE SECRET` SQL
- make existing secrets no-op by default and recreate them on `--full-refresh`
- add relation/drop/grants support for RisingWave secrets, including `USAGE` grants
- document secret usage and cover it in the source/connection e2e fixture

## Testing
- `git diff --check`
- `dbt-env/bin/python -m pytest tests/unit`
- local RisingWave smoke test for `CREATE SECRET`, `DROP SECRET`, `GRANT USAGE`, and `REVOKE USAGE`
- local source/connection e2e fixture: `dbt run --full-refresh`, `dbt test`, `dbt run`, `dbt test`, `dbt docs generate`