### PR TITLE
fix: avoid cascading zero-downtime cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,11 +598,15 @@ jobs:
       working-directory: tests/e2e/zero_downtime
       env:
         DBT_RW_ZERO_DOWNTIME_STAGE: changed
+    - name: dbt-cleanup-zero-downtime-temp-objects
+      run: dbt run-operation cleanup_temp_objects
+      working-directory: tests/e2e/zero_downtime
     - name: dbt-test-zero-downtime-swap
       run: dbt test
       working-directory: tests/e2e/zero_downtime
       env:
         DBT_RW_ZERO_DOWNTIME_EXPECT_STAGE: changed
+        DBT_RW_ZERO_DOWNTIME_EXPECT_TEMP_CLEANED: "true"
     - name: dbt-doc
       run: dbt docs generate
       working-directory: tests/e2e/zero_downtime

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -631,6 +631,48 @@
   alter materialized view {{ old_relation }} swap with {{ new_relation }}
 {%- endmacro %}
 
+{%- macro risingwave__relation_has_dependents(relation) -%}
+  {%- set relation_schema = relation.schema | replace("'", "''") -%}
+  {%- set relation_identifier = relation.identifier | replace("'", "''") -%}
+
+  {% call statement('zero_downtime_relation_has_dependents', fetch_result=True) -%}
+    select exists (
+      select 1
+      from rw_catalog.rw_depend
+      join rw_catalog.rw_relations on rw_depend.refobjid = rw_relations.id
+      join rw_catalog.rw_schemas on rw_relations.schema_id = rw_schemas.id
+      where rw_schemas.name = '{{ relation_schema }}'
+        and rw_relations.name = '{{ relation_identifier }}'
+    ) as has_dependents
+  {%- endcall %}
+
+  {%- set result_table = load_result('zero_downtime_relation_has_dependents').table -%}
+  {%- if result_table is none or result_table.rows | length == 0 -%}
+    {{ return(false) }}
+  {%- endif -%}
+
+  {{ return(result_table.rows[0][0]) }}
+{%- endmacro %}
+
+{%- macro risingwave__drop_zero_downtime_temp_relation(relation) -%}
+  {%- if risingwave__relation_has_dependents(relation) -%}
+    {{- log("Preserving zero-downtime temporary relation because dependent objects still reference it: " ~ relation) -}}
+    {{ return(false) }}
+  {%- endif -%}
+
+  {% call statement('drop_zero_downtime_temp_relation') -%}
+    {% if relation.type == 'view' %}
+      drop view if exists {{ relation }}
+    {% elif relation.type == 'materializedview' or relation.type == 'materialized_view' %}
+      drop materialized view if exists {{ relation }}
+    {% else %}
+      {{ exceptions.raise_compiler_error("Unsupported zero-downtime temporary relation type: " ~ relation.type) }}
+    {% endif %}
+  {%- endcall %}
+
+  {{ return(true) }}
+{%- endmacro %}
+
 
 
 
@@ -696,18 +738,20 @@
       ) -%}
       
       {% if dry_run %}
-        {{ print("DRY RUN: Would drop " ~ temp_obj[3] ~ " " ~ obj_relation) }}
+        {% if risingwave__relation_has_dependents(obj_relation) %}
+          {{ print("DRY RUN: Would preserve " ~ temp_obj[3] ~ " " ~ obj_relation ~ " because dependent objects still reference it") }}
+        {% else %}
+          {{ print("DRY RUN: Would drop " ~ temp_obj[3] ~ " " ~ obj_relation) }}
+        {% endif %}
       {% else %}
-        {{ print("Dropping temporary " ~ temp_obj[3] ~ ": " ~ obj_relation) }}
-        {% call statement('drop_temp_obj_' ~ loop.index) -%}
-          {% if temp_obj[3] == 'materialized view' %}
-            DROP MATERIALIZED VIEW IF EXISTS {{ obj_relation }} CASCADE
-          {% elif temp_obj[3] == 'view' %}
-            DROP VIEW IF EXISTS {{ obj_relation }} CASCADE
-          {% elif temp_obj[3] == 'sink' %}
-            DROP SINK IF EXISTS {{ obj_relation }} CASCADE
-          {% endif %}
-        {%- endcall %}
+        {% if temp_obj[3] == 'materialized view' or temp_obj[3] == 'view' %}
+          {{ risingwave__drop_zero_downtime_temp_relation(obj_relation) }}
+        {% elif temp_obj[3] == 'sink' %}
+          {{ print("Dropping temporary " ~ temp_obj[3] ~ ": " ~ obj_relation) }}
+          {% call statement('drop_temp_obj_' ~ loop.index) -%}
+            DROP SINK IF EXISTS {{ obj_relation }}
+          {%- endcall %}
+        {% endif %}
       {% endif %}
     {% endfor %}
     

--- a/dbt/include/risingwave/macros/materializations/materialized_view.sql
+++ b/dbt/include/risingwave/macros/materializations/materialized_view.sql
@@ -76,8 +76,8 @@
 
       {# Step 3: Conditionally drop the old materialized view (now with temp name) #}
       {% if immediate_cleanup %}
-        {{- log("Immediately cleaning up temporary materialized view: " ~ temp_relation) -}}
-        {{ risingwave__drop_relation(temp_relation) }}
+        {{- log("Attempting immediate cleanup of temporary materialized view: " ~ temp_relation) -}}
+        {{ risingwave__drop_zero_downtime_temp_relation(temp_relation) }}
       {% else %}
         {{- log("Preserving temporary materialized view for downstream dependencies: " ~ temp_relation) -}}
         {{- log("Manual cleanup required: DROP MATERIALIZED VIEW IF EXISTS " ~ temp_relation ~ ";") -}}

--- a/dbt/include/risingwave/macros/materializations/view.sql
+++ b/dbt/include/risingwave/macros/materializations/view.sql
@@ -61,8 +61,8 @@
 
       {# Step 3: Conditionally drop the old view (now with temp name) #}
       {% if immediate_cleanup %}
-        {{- log("Immediately cleaning up temporary view: " ~ temp_relation) -}}
-        {{ risingwave__drop_relation(temp_relation) }}
+        {{- log("Attempting immediate cleanup of temporary view: " ~ temp_relation) -}}
+        {{ risingwave__drop_zero_downtime_temp_relation(temp_relation) }}
       {% else %}
         {{- log("Preserving temporary view for downstream dependencies: " ~ temp_relation) -}}
         {{- log("Manual cleanup required: DROP VIEW IF EXISTS " ~ temp_relation ~ ";") -}}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -362,6 +362,7 @@ Limitations:
 ### Zero-Downtime Rebuilds
 
 `materialized_view` and `view` support swap-based zero-downtime rebuilds.
+Temporary cleanup is dependency-safe: if downstream objects still reference the swapped-out temporary object, cleanup preserves it instead of using `CASCADE`.
 
 ```sql
 {{ config(

--- a/docs/zero-downtime-rebuilds.md
+++ b/docs/zero-downtime-rebuilds.md
@@ -22,7 +22,7 @@ When a model already exists and zero downtime is enabled, the adapter:
 
 1. Creates a temporary object with the new definition.
 2. Swaps the temporary object with the original object.
-3. Either preserves or drops the old object, depending on `immediate_cleanup`.
+3. Either preserves or safely drops the old object, depending on `immediate_cleanup` and remaining dependencies.
 
 Temporary objects use the naming pattern `{original_name}_dbt_zero_down_tmp_{timestamp}`.
 
@@ -75,7 +75,7 @@ By default, temporary objects are preserved after the swap to avoid breaking dow
 ) }}
 ```
 
-To drop the temporary object immediately after the swap:
+To try to drop the temporary object immediately after the swap:
 
 ```sql
 {{ config(
@@ -84,7 +84,21 @@ To drop the temporary object immediately after the swap:
 ) }}
 ```
 
-Use immediate cleanup carefully because dependent objects may still refer to the pre-swap object graph.
+Immediate cleanup is dependency-safe and best-effort. RisingWave `SWAP WITH` keeps existing downstream objects attached to the pre-swap object ID, now renamed to the temporary object. If any dependent object still references that temporary object, the adapter preserves it even when `immediate_cleanup` is `true`; it does not use `CASCADE` for zero-downtime temporary object cleanup.
+
+For a chain such as `mv1 -> mv2 -> mv3`, updating only `mv1` can leave `mv2` and `mv3` reading from the preserved temporary `mv1` object. Rebuild dependent models when they should move to the new upstream definition:
+
+```bash
+dbt run --select "mv1+" --vars 'zero_downtime: true'
+```
+
+Then run cleanup after dependent models have been rebuilt:
+
+```bash
+dbt run-operation cleanup_temp_objects
+```
+
+The cleanup helper also skips temporary objects that still have dependents. Run it again after rebuilding more downstream objects if it reports preserved objects.
 
 ## When Swap-Based Rebuilds Apply
 

--- a/tests/e2e/zero_downtime/tests/assert_zero_downtime_materializations.sql
+++ b/tests/e2e/zero_downtime/tests/assert_zero_downtime_materializations.sql
@@ -1,4 +1,5 @@
 {% set expected_stage = env_var('DBT_RW_ZERO_DOWNTIME_EXPECT_STAGE', 'initial') %}
+{% set expect_temp_cleaned = env_var('DBT_RW_ZERO_DOWNTIME_EXPECT_TEMP_CLEANED', 'false') == 'true' %}
 
 {% if expected_stage not in ['initial', 'changed'] %}
   {{ exceptions.raise_compiler_error("Invalid DBT_RW_ZERO_DOWNTIME_EXPECT_STAGE: " ~ expected_stage) }}
@@ -65,7 +66,8 @@ where not exists (
 union all
 
 select 'zero-downtime temp relations should be cleaned up' as failure
-where exists (
+where {{ 'true' if expect_temp_cleaned else 'false' }}
+  and exists (
     select 1
     from rw_relations
     join rw_schemas on schema_id = rw_schemas.id

--- a/tests/unit/test_materialization_relation_lookup.py
+++ b/tests/unit/test_materialization_relation_lookup.py
@@ -99,6 +99,26 @@ def test_native_session_model_configs_are_allowlisted():
     assert "set database" not in adapter_macros.lower()
 
 
+def test_zero_downtime_immediate_cleanup_is_dependency_safe():
+    materialized_view = (MATERIALIZATION_DIR / "materialized_view.sql").read_text()
+    view = (MATERIALIZATION_DIR / "view.sql").read_text()
+    adapter_macros = ADAPTER_MACROS.read_text()
+
+    for materialization in (materialized_view, view):
+        assert "risingwave__drop_zero_downtime_temp_relation(temp_relation)" in materialization
+        assert "risingwave__drop_relation(temp_relation)" not in materialization
+
+    assert "rw_catalog.rw_depend" in adapter_macros
+    assert (
+        "Preserving zero-downtime temporary relation because dependent objects still reference it"
+        in adapter_macros
+    )
+    assert "drop materialized view if exists {{ relation }}" in adapter_macros
+    assert "drop view if exists {{ relation }}" in adapter_macros
+    assert "DROP MATERIALIZED VIEW IF EXISTS {{ obj_relation }} CASCADE" not in adapter_macros
+    assert "DROP VIEW IF EXISTS {{ obj_relation }} CASCADE" not in adapter_macros
+
+
 def test_profile_session_settings_are_allowlisted():
     connections = load_local_connections_module()
 


### PR DESCRIPTION
## Summary
- make zero-downtime temp cleanup dependency-aware via `rw_catalog.rw_depend`
- avoid `CASCADE` when dropping zero-downtime temp views/materialized views
- update zero-downtime docs, CI cleanup flow, and unit/e2e assertions

## Tests
- `dbt-env/bin/python -m pytest tests/unit`
- `dbt-env/bin/dbt parse --project-dir tests/e2e/zero_downtime --profile dbt_risingwave_functions`
- `git diff --check`

Local e2e was not run because `127.0.0.1:4566` had no RisingWave response.