### PR TITLE
Add adapter validation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ CREATE INDEX IF NOT EXISTS "__dbt_index_mv_user_id"
 
 Note: RisingWave does not support `unique` or `type` (index method) options from the Postgres adapter. These options are silently ignored.
 
+`dbt-risingwave` also emits adapter validation warnings for known unsupported or ignored model patterns,
+such as `retention_seconds` on `CREATE MATERIALIZED VIEW` or complete DDL statements inside query-based
+materializations. See [docs/configuration.md](docs/configuration.md#adapter-validation) for the warning
+list and the `risingwave_adapter_validation` mode.
+
 ## Materializations
 
 The adapter follows standard dbt model workflows, with RisingWave-specific materializations and behaviors.

--- a/dbt/include/risingwave/macros/materializations/connection.sql
+++ b/dbt/include/risingwave/macros/materializations/connection.sql
@@ -9,6 +9,8 @@
   ) -%}
   {%- set existing_connection = false -%}
 
+  {{ risingwave__validate_model_sql(sql, 'connection', false) }}
+
   {% if execute %}
     {% set connection_exists_sql %}
       select 1

--- a/dbt/include/risingwave/macros/materializations/incremental.sql
+++ b/dbt/include/risingwave/macros/materializations/incremental.sql
@@ -13,6 +13,8 @@
   {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}
   {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
 
+  {{ risingwave__validate_model_sql(sql, 'incremental', true) }}
+
   -- the temp_ and backup_ relations should not already exist in the database; get_relation
   -- will return None in that case. Otherwise, we get a relation that we can drop
   -- later, before we try to use this name for the current operation. This has to happen before

--- a/dbt/include/risingwave/macros/materializations/materialized_view.sql
+++ b/dbt/include/risingwave/macros/materializations/materialized_view.sql
@@ -15,6 +15,8 @@
   {%- set zero_downtime_mode = model_has_zero_downtime and user_requested_zero_downtime -%}
   {%- set immediate_cleanup = zero_downtime_config.get('immediate_cleanup', false) -%}
 
+  {{ risingwave__validate_model_sql(sql, 'materialized_view', true) }}
+
   {% if full_refresh_mode and old_relation %}
     {{ adapter.drop_relation(old_relation) }}
   {% endif %}

--- a/dbt/include/risingwave/macros/materializations/materializedview.sql
+++ b/dbt/include/risingwave/macros/materializations/materializedview.sql
@@ -9,6 +9,8 @@
                                                 database=database,
                                                 type='materializedview') -%}
 
+  {{ risingwave__validate_model_sql(sql, 'materializedview', true) }}
+
   {% if full_refresh_mode and old_relation %}
     {{ adapter.drop_relation(old_relation) }}
   {% endif %}

--- a/dbt/include/risingwave/macros/materializations/secret.sql
+++ b/dbt/include/risingwave/macros/materializations/secret.sql
@@ -11,6 +11,8 @@
   {%- set old_relation = none -%}
   {%- set grant_config = config.get("grants") -%}
 
+  {{ risingwave__validate_model_sql(sql, 'secret', false) }}
+
   {% if execute %}
     {% set secret_exists_sql %}
       select 1

--- a/dbt/include/risingwave/macros/materializations/sink.sql
+++ b/dbt/include/risingwave/macros/materializations/sink.sql
@@ -9,6 +9,9 @@
     ) -%}
     {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
     {%- set grant_config = config.get("grants") -%}
+    {%- set connector = config.get("connector") -%}
+
+    {{ risingwave__validate_model_sql(sql, "sink", connector is not none) }}
 
     {% if full_refresh_mode and old_relation %} {{ adapter.drop_relation(old_relation) }} {% endif %}
 
@@ -16,7 +19,6 @@
     {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
     {% if old_relation is none or (full_refresh_mode and old_relation) %}
-        {%- set connector = config.get("connector") -%}
         {% call statement("main") -%}
             {% if connector %} {{ risingwave__create_sink(target_relation, sql) }}
             {% else %} {{ risingwave__run_sql(sql) }}

--- a/dbt/include/risingwave/macros/materializations/source.sql
+++ b/dbt/include/risingwave/macros/materializations/source.sql
@@ -7,6 +7,8 @@
     {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
     {%- set grant_config = config.get("grants") -%}
 
+    {{ risingwave__validate_model_sql(sql, "source", false) }}
+
     {% if full_refresh_mode and old_relation %} {{ adapter.drop_relation(old_relation) }} {% endif %}
 
     {{ run_hooks(pre_hooks, inside_transaction=False) }}

--- a/dbt/include/risingwave/macros/materializations/subscription.sql
+++ b/dbt/include/risingwave/macros/materializations/subscription.sql
@@ -13,6 +13,8 @@
     {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
     {%- set grant_config = config.get("grants") -%}
 
+    {{ risingwave__validate_model_sql(sql, "subscription", true) }}
+
     {% if full_refresh_mode and old_relation %} {{ adapter.drop_relation(old_relation) }} {% endif %}
 
     {{ run_hooks(pre_hooks, inside_transaction=False) }}

--- a/dbt/include/risingwave/macros/materializations/table.sql
+++ b/dbt/include/risingwave/macros/materializations/table.sql
@@ -10,6 +10,8 @@
                                                 type='table') -%}
   {%- set grant_config = config.get('grants') -%}
 
+  {{ risingwave__validate_model_sql(sql, 'table', true) }}
+
   {% if full_refresh_mode and old_relation %}
     {{ adapter.drop_relation(old_relation) }}
   {% endif %}

--- a/dbt/include/risingwave/macros/materializations/table_with_connector.sql
+++ b/dbt/include/risingwave/macros/materializations/table_with_connector.sql
@@ -7,6 +7,8 @@
     {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
     {%- set grant_config = config.get("grants") -%}
 
+    {{ risingwave__validate_model_sql(sql, "table_with_connector", false) }}
+
     {% if full_refresh_mode and old_relation %} {{ adapter.drop_relation(old_relation) }} {% endif %}
 
     {{ run_hooks(pre_hooks, inside_transaction=False) }}

--- a/dbt/include/risingwave/macros/materializations/view.sql
+++ b/dbt/include/risingwave/macros/materializations/view.sql
@@ -15,6 +15,8 @@
   {%- set zero_downtime_mode = model_has_zero_downtime and user_requested_zero_downtime -%}
   {%- set immediate_cleanup = zero_downtime_config.get('immediate_cleanup', false) -%}
 
+  {{ risingwave__validate_model_sql(sql, 'view', true) }}
+
   {% if full_refresh_mode and old_relation %}
     {{ adapter.drop_relation(old_relation) }}
   {% endif %}

--- a/dbt/include/risingwave/macros/validation.sql
+++ b/dbt/include/risingwave/macros/validation.sql
@@ -1,0 +1,130 @@
+{% macro risingwave__validation_mode() -%}
+  {%- set mode = var('risingwave_adapter_validation', 'warn') -%}
+  {%- if mode is none -%}
+    {{ return('warn') }}
+  {%- endif -%}
+  {%- set normalized_mode = mode | string | lower | trim -%}
+  {%- if normalized_mode in ['warn', 'error', 'off'] -%}
+    {{ return(normalized_mode) }}
+  {%- endif -%}
+
+  {{ exceptions.raise_compiler_error(
+    "`risingwave_adapter_validation` must be one of `warn`, `error`, or `off`, got `" ~ mode ~ "`."
+  ) }}
+{%- endmacro %}
+
+
+{% macro risingwave__validation_report(code, message) -%}
+  {%- set mode = risingwave__validation_mode() -%}
+  {%- set formatted_message = "[dbt-risingwave " ~ code ~ "] " ~ message -%}
+  {%- if mode == 'off' -%}
+  {%- elif mode == 'error' -%}
+    {{ exceptions.raise_compiler_error(formatted_message) }}
+  {%- else -%}
+    {{ exceptions.warn(formatted_message) }}
+  {%- endif -%}
+{%- endmacro %}
+
+
+{% macro risingwave__looks_like_ddl(sql) -%}
+  {%- set normalized_sql = (sql | default('', true)) | trim | lower -%}
+  {%- if normalized_sql.startswith('create ')
+      or normalized_sql.startswith('drop ')
+      or normalized_sql.startswith('alter ')
+      or normalized_sql.startswith('truncate ') -%}
+    {{ return(true) }}
+  {%- endif -%}
+  {{ return(false) }}
+{%- endmacro %}
+
+
+{% macro risingwave__validate_ignored_index_options(materialization) -%}
+  {%- set indexes = config.get('indexes', []) -%}
+  {%- if indexes is none -%}
+    {%- set indexes = [] -%}
+  {%- endif -%}
+
+  {%- for index_config in indexes -%}
+    {%- if index_config is mapping -%}
+      {%- if index_config.get('unique', none) is not none -%}
+        {{ risingwave__validation_report(
+          'RW004',
+          "`indexes[].unique` is a PostgreSQL adapter option and is ignored by dbt-risingwave. "
+          ~ "Remove it from the `" ~ materialization ~ "` model index config."
+        ) }}
+      {%- endif -%}
+      {%- if index_config.get('type', none) is not none -%}
+        {{ risingwave__validation_report(
+          'RW005',
+          "`indexes[].type` is a PostgreSQL adapter option and is ignored by dbt-risingwave. "
+          ~ "Remove it from the `" ~ materialization ~ "` model index config."
+        ) }}
+      {%- endif -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endmacro %}
+
+
+{% macro risingwave__validate_model_sql(sql, materialization, wraps_model_sql=false) -%}
+  {%- set normalized_sql = (sql | default('', true)) | trim | lower -%}
+
+  {%- if wraps_model_sql and risingwave__looks_like_ddl(normalized_sql) -%}
+    {{ risingwave__validation_report(
+      'RW001',
+      "`" ~ materialization ~ "` wraps model SQL in adapter-managed DDL, so the model SQL should "
+      ~ "usually be a query expression rather than a full DDL statement. Use a raw-DDL "
+      ~ "materialization such as `source`, `connection`, `secret`, `table_with_connector`, or raw `sink` "
+      ~ "when the model needs to provide the complete RisingWave DDL."
+    ) }}
+  {%- endif -%}
+
+  {%- if 'create materialized view' in normalized_sql and 'retention_seconds' in normalized_sql -%}
+    {{ risingwave__validation_report(
+      'RW002',
+      "`retention_seconds` is not a supported option on `CREATE MATERIALIZED VIEW`. "
+      ~ "Use `subscription` with `retention` for cross-database MV retention, or an append-only "
+      ~ "`CREATE TABLE ... WITH (retention_seconds = ...)` when table storage TTL is intended."
+    ) }}
+  {%- endif -%}
+
+  {%- if 'create subscription' in normalized_sql and 'retention_seconds' in normalized_sql -%}
+    {{ risingwave__validation_report(
+      'RW003',
+      "`CREATE SUBSCRIPTION` uses `WITH (retention = ...)`, not `retention_seconds`."
+    ) }}
+  {%- endif -%}
+
+  {%- if config.get('retention_seconds', none) is not none -%}
+    {{ risingwave__validation_report(
+      'RW006',
+      "`retention_seconds` is not rendered from dbt model config by dbt-risingwave. "
+      ~ "Put it in a raw RisingWave `CREATE TABLE ... WITH (...)` statement when table storage TTL is intended."
+    ) }}
+  {%- endif -%}
+
+  {%- if materialization != 'subscription' and config.get('retention', none) is not none -%}
+    {{ risingwave__validation_report(
+      'RW007',
+      "`retention` is only used by the `subscription` materialization. It is ignored by `"
+      ~ materialization ~ "`."
+    ) }}
+  {%- endif -%}
+
+  {%- if materialization != 'subscription' and config.get('subscription_options', none) is not none -%}
+    {{ risingwave__validation_report(
+      'RW008',
+      "`subscription_options` is only used by the `subscription` materialization. It is ignored by `"
+      ~ materialization ~ "`."
+    ) }}
+  {%- endif -%}
+
+  {%- if materialization not in ['materialized_view', 'view'] and config.get('zero_downtime', none) is not none -%}
+    {{ risingwave__validation_report(
+      'RW009',
+      "`zero_downtime` is only supported by the `materialized_view` and `view` materializations. "
+      ~ "It is ignored by `" ~ materialization ~ "`."
+    ) }}
+  {%- endif -%}
+
+  {{ risingwave__validate_ignored_index_options(materialization) }}
+{%- endmacro %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -434,3 +434,26 @@ with (
 ## Related dbt Configs
 
 The adapter also works with standard dbt configs such as `indexes`, `contract`, `grants`, `unique_key`, and `on_schema_change`. Refer to the dbt docs for the generic semantics; this page focuses on RisingWave-specific behavior.
+
+### Adapter Validation
+
+`dbt-risingwave` emits best-effort warnings for known unsupported or ignored RisingWave-specific model patterns before running adapter-managed DDL. These checks intentionally cover only high-confidence cases that can be identified from model SQL or dbt config without connecting to RisingWave catalog state.
+
+Examples include:
+
+- full `CREATE`, `DROP`, `ALTER`, or `TRUNCATE` statements inside query-based materializations such as `materialized_view`, `table`, `view`, `incremental`, and adapter-managed `sink`
+- `retention_seconds` on `CREATE MATERIALIZED VIEW`
+- `retention_seconds` on `CREATE SUBSCRIPTION` instead of `retention`
+- dbt model config keys that this adapter does not render, such as `retention_seconds` as model config
+- subscription-only configs such as `retention` or `subscription_options` on non-`subscription` materializations
+- `zero_downtime` on materializations other than `materialized_view` and `view`
+- PostgreSQL index options `unique` and `type`, which RisingWave ignores
+
+Warnings are enabled by default. Projects can make them fail compilation or disable them:
+
+```yaml
+vars:
+  risingwave_adapter_validation: warn   # warn, error, or off
+```
+
+Use `error` in CI when you want these adapter-specific checks to block the run.

--- a/tests/unit/test_materialization_relation_lookup.py
+++ b/tests/unit/test_materialization_relation_lookup.py
@@ -13,6 +13,7 @@ MATERIALIZATION_DIR = (
     / "materializations"
 )
 ADAPTER_MACROS = MATERIALIZATION_DIR.parent / "adapters.sql"
+VALIDATION_MACROS = MATERIALIZATION_DIR.parent / "validation.sql"
 CONNECTIONS = MATERIALIZATION_DIR.parents[3] / "adapters" / "risingwave" / "connections.py"
 
 NATIVE_MODEL_SESSION_SETTINGS = {
@@ -97,6 +98,42 @@ def test_native_session_model_configs_are_allowlisted():
     assert 'config.get("background_ddl", none)' in adapter_macros
     assert "risingwave__native_model_session_settings()" in adapter_macros
     assert "set database" not in adapter_macros.lower()
+
+
+def test_adapter_validation_rules_are_documented_in_macro():
+    validation_macros = VALIDATION_MACROS.read_text()
+
+    assert "risingwave_adapter_validation" in validation_macros
+    assert "`retention_seconds` is not a supported option on `CREATE MATERIALIZED VIEW`" in validation_macros
+    assert "`CREATE SUBSCRIPTION` uses `WITH (retention = ...)`" in validation_macros
+    assert "`indexes[].unique` is a PostgreSQL adapter option" in validation_macros
+    assert "`indexes[].type` is a PostgreSQL adapter option" in validation_macros
+    assert "`zero_downtime` is only supported" in validation_macros
+    assert "RW001" in validation_macros
+    assert "RW009" in validation_macros
+
+
+def test_adapter_validation_is_wired_into_materializations():
+    expected_calls = {
+        "materialized_view.sql": "risingwave__validate_model_sql(sql, 'materialized_view', true)",
+        "materializedview.sql": "risingwave__validate_model_sql(sql, 'materializedview', true)",
+        "table.sql": "risingwave__validate_model_sql(sql, 'table', true)",
+        "view.sql": "risingwave__validate_model_sql(sql, 'view', true)",
+        "incremental.sql": "risingwave__validate_model_sql(sql, 'incremental', true)",
+        "subscription.sql": 'risingwave__validate_model_sql(sql, "subscription", true)',
+        "source.sql": 'risingwave__validate_model_sql(sql, "source", false)',
+        "table_with_connector.sql": 'risingwave__validate_model_sql(sql, "table_with_connector", false)',
+        "connection.sql": "risingwave__validate_model_sql(sql, 'connection', false)",
+        "secret.sql": "risingwave__validate_model_sql(sql, 'secret', false)",
+    }
+
+    for filename, expected_call in expected_calls.items():
+        materialization = (MATERIALIZATION_DIR / filename).read_text()
+        assert expected_call in materialization
+
+    sink = (MATERIALIZATION_DIR / "sink.sql").read_text()
+    assert 'config.get("connector")' in sink
+    assert 'risingwave__validate_model_sql(sql, "sink", connector is not none)' in sink
 
 
 def test_zero_downtime_immediate_cleanup_is_dependency_safe():


### PR DESCRIPTION
## Summary

- add `risingwave__validate_model_sql` for best-effort warnings on known unsupported or ignored model patterns
- wire validation into query-based and raw-DDL materializations, including adapter-managed sink behavior
- document `risingwave_adapter_validation` (`warn`, `error`, `off`) and add unit coverage for rule/call wiring

Refs #146.

## Validation

- `.venv/bin/python -m pytest tests/unit`
- `.venv/bin/dbt parse --project-dir tests/e2e/basic_models --profiles-dir /tmp/dbt-rw-profiles --target dev`
- `.venv/bin/dbt run-operation risingwave__validate_model_sql --args '{sql: "create materialized view mv with (retention_seconds = 10) as select 1", materialization: materialized_view, wraps_model_sql: true}' --project-dir tests/e2e/basic_models --profiles-dir /tmp/dbt-rw-profiles --target dev`\n- `git diff --check`