### PR TITLE
feat(sink): support zero-downtime replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,13 @@ See [docs/configuration.md](docs/configuration.md) for supported materialization
 
 ### Zero-Downtime Rebuilds
 
-`materialized_view` and `view` support swap-based zero-downtime rebuilds through `zero_downtime={'enabled': true}` plus the runtime flag `--vars 'zero_downtime: true'`.
+`materialized_view` and `view` support swap-based zero-downtime rebuilds. Supported
+adapter-managed `sink` models can use RisingWave `REPLACE SINK` for cut-over. Both paths
+require `zero_downtime={'enabled': true}` plus the runtime flag
+`--vars 'zero_downtime: true'`.
 
-See [docs/zero-downtime-rebuilds.md](docs/zero-downtime-rebuilds.md) for requirements, cleanup behavior, and helper commands.
+See [docs/zero-downtime-rebuilds.md](docs/zero-downtime-rebuilds.md) for requirements,
+current sink limitations, cleanup behavior, and helper commands.
 
 ### Functions
 
@@ -175,7 +179,7 @@ See [docs/configuration.md](docs/configuration.md) for adapter-specific configur
 - [docs/README.md](docs/README.md): documentation index
 - [docs/configuration.md](docs/configuration.md): profile options, model configs, sink settings, and background DDL usage
 - [docs/functions.md](docs/functions.md): first-version RisingWave scalar function support and limitations
-- [docs/zero-downtime-rebuilds.md](docs/zero-downtime-rebuilds.md): zero-downtime rebuild behavior for materialized views and views
+- [docs/zero-downtime-rebuilds.md](docs/zero-downtime-rebuilds.md): zero-downtime rebuilds for views and materialized views, plus supported sink cut-overs
 
 ## dbt Run Behavior
 

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -286,7 +286,27 @@
     {{ risingwave__create_materialized_view_as(relation, sql) }}
 {%- endmacro %}
 
-{% macro risingwave__create_sink(relation, sql) -%}
+{% macro risingwave__replace_sink_from_relation(sql, connector) -%}
+    {%- if connector is none -%}
+        {{ exceptions.raise_compiler_error(
+            "Zero downtime sink replacement is only supported for adapter-managed sinks with `connector` configured. "
+            ~ "Raw sink DDL cannot be safely rewritten from CREATE SINK to REPLACE SINK."
+        ) }}
+    {%- endif -%}
+
+    {%- set from_relation = (sql | default('', true)) | trim -%}
+    {%- if from_relation == '' or from_relation.split() | length != 1 -%}
+        {{ exceptions.raise_compiler_error(
+            "Zero downtime sink replacement currently requires model SQL that renders to one upstream relation, "
+            ~ "for example `{{ ref('orders_mv') }}`. RisingWave REPLACE SINK does not support AS query yet."
+        ) }}
+    {%- endif -%}
+
+    {{ return(from_relation) }}
+{%- endmacro %}
+
+
+{% macro risingwave__sink_ddl(relation, sql, replace_existing=false, from_relation=none) -%}
     {{ risingwave__render_sql_header() }}
 
     {%- set _format_parameters = config.get("format_parameters") -%}
@@ -296,12 +316,17 @@
     {%- set _connector_parameters = config.require("connector_parameters") -%}
     {%- set connector = config.require("connector") -%}
 
+    {% if replace_existing -%}
+    replace sink {{ relation }}
+        from {{ from_relation }}
+    {%- else -%}
     create sink if not exists {{ relation }}
       {% if "select" in sql.lower() -%}
         as {{ sql }}
       {%- else -%}
         from {{ sql }}
       {%- endif %}
+    {%- endif %}
     with (
           connector = '{{ connector }}',
           {%- for key, value in _connector_parameters.items() %}
@@ -318,6 +343,16 @@
     )
     {%- endif -%}
     ;
+{%- endmacro %}
+
+
+{% macro risingwave__create_sink(relation, sql) -%}
+    {{ risingwave__sink_ddl(relation, sql) }}
+{%- endmacro %}
+
+
+{% macro risingwave__replace_sink(relation, from_relation) -%}
+    {{ risingwave__sink_ddl(relation, none, replace_existing=true, from_relation=from_relation) }}
 {%- endmacro %}
 
 {% macro risingwave__create_subscription(relation, sql) -%}
@@ -421,6 +456,11 @@
   {% if not risingwave__background_ddl_enabled() %}
     {{ return("") }}
   {% endif %}
+  {% do run_query('WAIT') %}
+{% endmacro %}
+
+{% macro risingwave__wait_for_replace_sink() %}
+  {# RisingWave forces replacement sinks to background creation for recovery safety. #}
   {% do run_query('WAIT') %}
 {% endmacro %}
 

--- a/dbt/include/risingwave/macros/materializations/sink.sql
+++ b/dbt/include/risingwave/macros/materializations/sink.sql
@@ -10,10 +10,25 @@
     {%- set old_relation = risingwave__get_relation_without_caching(target_relation) -%}
     {%- set grant_config = config.get("grants") -%}
     {%- set connector = config.get("connector") -%}
+    {%- set zero_downtime_config = config.get("zero_downtime", {}) -%}
+    {%- set model_has_zero_downtime = zero_downtime_config.get("enabled", false) -%}
+    {%- set user_requested_zero_downtime = var("zero_downtime", false) -%}
+    {%- set zero_downtime_mode = model_has_zero_downtime and user_requested_zero_downtime -%}
+    {%- set replace_mode = old_relation is not none and not full_refresh_mode and zero_downtime_mode -%}
+    {%- set replace_from_relation = none -%}
+
+    {% if replace_mode %}
+        {%- set replace_from_relation = risingwave__replace_sink_from_relation(sql, connector) -%}
+    {% endif %}
 
     {{ risingwave__validate_model_sql(sql, "sink", connector is not none) }}
 
-    {% if full_refresh_mode and old_relation %} {{ adapter.drop_relation(old_relation) }} {% endif %}
+    {% if full_refresh_mode and old_relation %}
+        {% if zero_downtime_mode %}
+            {{- log("Zero downtime sink replacement is disabled under --full-refresh because REPLACE SINK does not backfill. Using drop/create.") -}}
+        {% endif %}
+        {{ adapter.drop_relation(old_relation) }}
+    {% endif %}
 
     {{ run_hooks(pre_hooks, inside_transaction=False) }}
     {{ run_hooks(pre_hooks, inside_transaction=True) }}
@@ -25,10 +40,17 @@
             {% endif %}
         {%- endcall %}
         {{ risingwave__wait_for_background_ddl(target_relation, "sink") }}
+    {% elif replace_mode %}
+        {{- log("Using REPLACE SINK for zero downtime sink cut-over.") -}}
+        {% call statement("main") -%}
+            {{ risingwave__replace_sink(target_relation, replace_from_relation) }}
+        {%- endcall %}
+        {{ risingwave__wait_for_replace_sink() }}
     {% else %} {{ risingwave__execute_no_op(target_relation) }}
     {% endif %}
 
-    {% set should_revoke = should_revoke(existing_relation=old_relation, full_refresh_mode=full_refresh_mode) %}
+    {%- set relation_recreated = full_refresh_mode or replace_mode -%}
+    {% set should_revoke = should_revoke(existing_relation=old_relation, full_refresh_mode=relation_recreated) %}
     {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
     {% do persist_docs(target_relation, model) %}

--- a/dbt/include/risingwave/macros/validation.sql
+++ b/dbt/include/risingwave/macros/validation.sql
@@ -118,10 +118,10 @@
     ) }}
   {%- endif -%}
 
-  {%- if materialization not in ['materialized_view', 'view'] and config.get('zero_downtime', none) is not none -%}
+  {%- if materialization not in ['materialized_view', 'view', 'sink'] and config.get('zero_downtime', none) is not none -%}
     {{ risingwave__validation_report(
       'RW009',
-      "`zero_downtime` is only supported by the `materialized_view` and `view` materializations. "
+      "`zero_downtime` is only supported by the `materialized_view`, `view`, and `sink` materializations. "
       ~ "It is ignored by `" ~ materialization ~ "`."
     ) }}
   {%- endif -%}

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ This directory contains the adapter-specific documentation that used to be mixed
 
 - [configuration.md](configuration.md): profile settings, model configuration, sink options, and subscriptions
 - [functions.md](functions.md): first-version RisingWave function support and its limits
-- [zero-downtime-rebuilds.md](zero-downtime-rebuilds.md): zero-downtime rebuild flow for materialized views and views
+- [zero-downtime-rebuilds.md](zero-downtime-rebuilds.md): zero-downtime rebuild flow for views and materialized views, plus supported sink cut-overs
 
 ## Start Here
 
@@ -15,4 +15,4 @@ If you are new to the adapter:
 1. Read the root [README.md](../README.md) for installation and basic project setup.
 2. Read [configuration.md](configuration.md) for RisingWave-specific configuration.
 3. Read [functions.md](functions.md) if you plan to manage RisingWave scalar UDFs with dbt.
-4. Read [zero-downtime-rebuilds.md](zero-downtime-rebuilds.md) if you plan to use swap-based rebuilds.
+4. Read [zero-downtime-rebuilds.md](zero-downtime-rebuilds.md) if you plan to use swap-based rebuilds or sink cut-overs.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -361,8 +361,11 @@ Limitations:
 
 ### Zero-Downtime Rebuilds
 
-`materialized_view` and `view` support swap-based zero-downtime rebuilds.
-Temporary cleanup is dependency-safe: if downstream objects still reference the swapped-out temporary object, cleanup preserves it instead of using `CASCADE`.
+`materialized_view` and `view` support swap-based zero-downtime rebuilds. Adapter-managed
+`sink` models can use `REPLACE SINK` for zero-downtime cut-over when the model SQL renders
+to one upstream relation. Temporary cleanup for views and materialized views is
+dependency-safe: if downstream objects still reference the swapped-out temporary object,
+cleanup preserves it instead of using `CASCADE`.
 
 ```sql
 {{ config(
@@ -416,6 +419,40 @@ Supported sink-specific configs:
 | `data_format` | No | Sink format used in `FORMAT ...`. |
 | `data_encode` | No | Sink encoding used in `ENCODE ...`. |
 | `format_parameters` | No | Extra format/encode options emitted inside `FORMAT ... ENCODE ... (...)`. |
+| `zero_downtime` | No | Set `{'enabled': true}` to allow an existing sink to be cut over with `REPLACE SINK` when the runtime flag is also enabled. |
+
+Zero-downtime sink replacement requires a RisingWave build containing `REPLACE SINK`
+(planned for RisingWave v3.1.0). The current RisingWave implementation accepts only
+`REPLACE SINK ... FROM relation`, so the model body must render to one relation rather than
+a `SELECT` query:
+
+```sql
+{{ config(
+    materialized='sink',
+    connector='kafka',
+    connector_parameters={
+      'topic': 'orders',
+      'properties.bootstrap.server': '127.0.0.1:9092'
+    },
+    data_format='plain',
+    data_encode='json',
+    format_parameters={},
+    zero_downtime={'enabled': true}
+) }}
+
+{{ ref('orders_mv') }}
+```
+
+Run the replacement without `--full-refresh`:
+
+```bash
+dbt run --select orders_sink --vars 'zero_downtime: true'
+```
+
+Raw sink DDL and query-based `CREATE SINK ... AS SELECT ...` models are not rewritten.
+RisingWave also currently rejects replacement for exactly-once sinks, sink-into-table,
+auto schema change sinks, and sinks using `since_timestamp`. `REPLACE SINK` starts at the
+cut-over barrier with `snapshot=false`; it does not reload historical rows.
 
 ### Raw SQL Sink DDL
 
@@ -446,7 +483,7 @@ Examples include:
 - `retention_seconds` on `CREATE SUBSCRIPTION` instead of `retention`
 - dbt model config keys that this adapter does not render, such as `retention_seconds` as model config
 - subscription-only configs such as `retention` or `subscription_options` on non-`subscription` materializations
-- `zero_downtime` on materializations other than `materialized_view` and `view`
+- `zero_downtime` on materializations other than `materialized_view`, `view`, and `sink`
 - PostgreSQL index options `unique` and `type`, which RisingWave ignores
 
 Warnings are enabled by default. Projects can make them fail compilation or disable them:

--- a/docs/zero-downtime-rebuilds.md
+++ b/docs/zero-downtime-rebuilds.md
@@ -1,11 +1,13 @@
-# Zero Downtime Rebuilds for Materialized Views and Views
+# Zero-Downtime Rebuilds and Sink Cut-Overs
 
 ## Overview
 
-This feature enables zero-downtime rebuilds for both materialized views and views by using swap-based updates.
+This feature enables zero-downtime rebuilds for materialized views and views, and
+zero-downtime cut-over for supported sinks.
 
 - Materialized views use `ALTER MATERIALIZED VIEW ... SWAP WITH ...`
 - Views use `ALTER VIEW ... SWAP WITH ...`
+- Sinks use `REPLACE SINK ... FROM relation`
 
 This keeps the original object name available during the update.
 
@@ -15,6 +17,10 @@ This keeps the original object name available during the update.
 - Zero-downtime materialized view rebuilds are supported only on `materialized_view`.
 - The deprecated `materializedview` materialization is not supported.
 - View swap is supported on the `view` materialization.
+- Sink cut-over requires a RisingWave build containing `REPLACE SINK` (planned for
+  RisingWave v3.1.0).
+- Sink cut-over is supported only for adapter-managed `sink` models whose SQL renders to
+  one upstream relation. Raw sink DDL and `CREATE SINK ... AS SELECT ...` are not rewritten.
 
 ## How It Works
 
@@ -26,9 +32,13 @@ When a model already exists and zero downtime is enabled, the adapter:
 
 Temporary objects use the naming pattern `{original_name}_dbt_zero_down_tmp_{timestamp}`.
 
+For a supported sink, the adapter instead issues `REPLACE SINK` directly. RisingWave
+creates a replacement sink job, drains the old sink at the cut-over barrier, and exposes
+the replacement under the original name. No temporary dbt relation is created.
+
 ## Enabling the Feature
 
-Zero-downtime rebuilds require both model configuration and a runtime flag.
+Zero-downtime operations require both model configuration and a runtime flag.
 
 ### Model Configuration
 
@@ -56,6 +66,28 @@ select *
 from {{ ref('source_table') }}
 ```
 
+For an adapter-managed sink, the model body must be only an upstream relation:
+
+```sql
+{{ config(
+    materialized='sink',
+    connector='kafka',
+    connector_parameters={
+      'topic': 'orders',
+      'properties.bootstrap.server': '127.0.0.1:9092'
+    },
+    data_format='plain',
+    data_encode='json',
+    format_parameters={},
+    zero_downtime={'enabled': true}
+) }}
+
+{{ ref('orders_mv') }}
+```
+
+Do not wrap the relation in `SELECT * FROM ...`; the current RisingWave command does not
+support `REPLACE SINK ... AS query`.
+
 ### Runtime Flag
 
 ```bash
@@ -65,6 +97,9 @@ dbt run --vars 'zero_downtime: true'
 If the runtime flag is omitted, the adapter falls back to the normal rebuild flow even when the model is configured for zero downtime.
 
 ## Cleanup Behavior
+
+This section applies to the temporary objects created by view and materialized-view swaps;
+sink replacement does not create a dbt temporary relation.
 
 By default, temporary objects are preserved after the swap to avoid breaking downstream dependencies.
 
@@ -100,9 +135,9 @@ dbt run-operation cleanup_temp_objects
 
 The cleanup helper also skips temporary objects that still have dependents. Run it again after rebuilding more downstream objects if it reports preserved objects.
 
-## When Swap-Based Rebuilds Apply
+## When Zero-Downtime Mode Applies
 
-The adapter uses zero-downtime rebuilds only when all of the following are true:
+The adapter uses zero-downtime mode only when all of the following are true:
 
 1. The relation already exists.
 2. The run is not using `--full-refresh`.
@@ -111,9 +146,29 @@ The adapter uses zero-downtime rebuilds only when all of the following are true:
 
 Otherwise, dbt-risingwave uses the standard handling path.
 
+For sinks, `--full-refresh` deliberately keeps the existing drop/create behavior because
+`REPLACE SINK` always uses `snapshot=false` and cannot provide full-refresh semantics.
+Run a sink cut-over without `--full-refresh`.
+
+## Current Sink Limitations
+
+The current RisingWave implementation rejects `REPLACE SINK` for:
+
+- exactly-once sinks, including Iceberg sinks that use exactly-once state;
+- sink-into-table;
+- auto schema change sinks;
+- sinks using `since_timestamp`; and
+- query-based `REPLACE SINK ... AS query`.
+
+The replacement starts from the cut-over barrier and does not backfill historical rows
+from the new upstream. RisingWave gives the replacement a new sink object id, so privileges
+configured through dbt are reapplied after replacement; privileges managed outside dbt are
+not preserved automatically.
+
 ## Manual Cleanup Helpers
 
-The adapter includes helper macros for listing and cleaning up preserved temporary objects.
+The adapter includes helper macros for listing and cleaning up preserved view and
+materialized-view temporary objects. They do not apply to sinks.
 
 ```bash
 dbt run-operation list_temp_objects

--- a/tests/e2e/sinks/models/replaceable_blackhole_sink.sql
+++ b/tests/e2e/sinks/models/replaceable_blackhole_sink.sql
@@ -1,0 +1,11 @@
+{{ config(
+    materialized='sink',
+    connector='blackhole',
+    connector_parameters={
+      'type': 'append-only',
+      'force_append_only': 'true'
+    },
+    zero_downtime={'enabled': true}
+) }}
+
+{{ ref('sink_source_mv') }}

--- a/tests/e2e/sinks/tests/assert_sink_materializations.sql
+++ b/tests/e2e/sinks/tests/assert_sink_materializations.sql
@@ -46,6 +46,18 @@ where not exists (
 
 union all
 
+select 'replaceable_blackhole_sink must be a sink' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'replaceable_blackhole_sink'
+      and rw_relations.relation_type = 'sink'
+)
+
+union all
+
 select 'sink_source_mv has unexpected row count' as failure
 where (select count(*) from {{ ref('sink_source_mv') }}) != 2
 

--- a/tests/unit/test_materialization_relation_lookup.py
+++ b/tests/unit/test_materialization_relation_lookup.py
@@ -156,6 +156,26 @@ def test_zero_downtime_immediate_cleanup_is_dependency_safe():
     assert "DROP VIEW IF EXISTS {{ obj_relation }} CASCADE" not in adapter_macros
 
 
+def test_sink_zero_downtime_uses_replace_sink_for_from_relation():
+    sink = (MATERIALIZATION_DIR / "sink.sql").read_text()
+    adapter_macros = ADAPTER_MACROS.read_text()
+    validation_macros = VALIDATION_MACROS.read_text()
+
+    assert 'config.get("zero_downtime", {})' in sink
+    assert 'var("zero_downtime", false)' in sink
+    assert "old_relation is not none and not full_refresh_mode and zero_downtime_mode" in sink
+    assert "risingwave__replace_sink(target_relation, replace_from_relation)" in sink
+    assert "risingwave__wait_for_replace_sink()" in sink
+    assert "full_refresh_mode=relation_recreated" in sink
+    assert "replace sink {{ relation }}" in adapter_macros
+    assert "macro risingwave__wait_for_replace_sink()" in adapter_macros
+    assert "forces replacement sinks to background creation" in adapter_macros
+    assert "replace sink if not exists" not in adapter_macros
+    assert "RisingWave REPLACE SINK does not support AS query yet" in adapter_macros
+    assert "Raw sink DDL cannot be safely rewritten" in adapter_macros
+    assert "['materialized_view', 'view', 'sink']" in validation_macros
+
+
 def test_profile_session_settings_are_allowlisted():
     connections = load_local_connections_module()
 


### PR DESCRIPTION
## Summary

- add opt-in zero-downtime replacement for adapter-managed sink models
- require both `zero_downtime={'enabled': true}` in model config and `--vars '{zero_downtime: true}'` at runtime
- use `REPLACE SINK ... FROM relation` only for an existing sink outside `--full-refresh`
- wait for replacement completion and reapply grants
- reject raw DDL and query-based sink models with a clear error because RisingWave does not support replacing those forms yet
- document the supported RisingWave version and current `REPLACE SINK` limitations

`--full-refresh` intentionally keeps the existing drop/create behavior because `REPLACE SINK` starts at the cut-over barrier and does not backfill historical rows.

RisingWave support was added in [risingwave#26039](https://github.com/risingwavelabs/risingwave/pull/26039). The catalog cleanup bug found during adapter testing is fixed separately in [risingwave#26266](https://github.com/risingwavelabs/risingwave/pull/26266).

## Testing

- `dbt-env/bin/python -m pytest tests/unit` (`13 passed`)
- `dbt parse` on the sink e2e project
- local RisingWave `3.1.0-alpha` started with `risedev d full`
- Kafka create-to-replace cut-over: dbt generated `REPLACE SINK ... FROM new_input`, executed `WAIT`, and Kafka contained only `old-before-replace` and `new-after-replace`
- replacement followed by `dbt run --full-refresh`: passed, sink ID changed from `45` to `48`
- final `DROP SCHEMA ... CASCADE`: passed with zero orphan internal-table object rows
