### PR TITLE
fix: prebuild indexes for zero-downtime MV swaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,6 +598,12 @@ jobs:
       working-directory: tests/e2e/zero_downtime
       env:
         DBT_RW_ZERO_DOWNTIME_STAGE: changed
+    - name: dbt-test-zero-downtime-index-handoff
+      run: dbt test --select assert_zero_downtime_index
+      working-directory: tests/e2e/zero_downtime
+      env:
+        DBT_RW_ZERO_DOWNTIME_EXPECT_STAGE: changed
+        DBT_RW_ZERO_DOWNTIME_EXPECT_INDEX_TEMP: "true"
     - name: dbt-cleanup-zero-downtime-temp-objects
       run: dbt run-operation cleanup_temp_objects
       working-directory: tests/e2e/zero_downtime

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -210,6 +210,67 @@
      "{{ db_name }}"."{{ schema_name }}"."{{ index_name }}";
 {%- endmacro -%}
 
+{%- macro risingwave__get_rename_index_sql(relation, old_index_name, new_index_name) -%}
+    {%- set db_name = relation.database -%}
+    {%- set schema_name = relation.schema -%}
+
+    alter index
+     "{{ db_name }}"."{{ schema_name }}"."{{ old_index_name }}"
+    rename to "{{ new_index_name }}";
+{%- endmacro -%}
+
+{%- macro risingwave__handoff_zero_downtime_indexes(staged_relation, target_relation) -%}
+  {%- set index_configs = config.get('indexes', []) -%}
+  {%- set target_identifier = target_relation.identifier -%}
+  {%- set target_schema_literal = target_relation.schema | replace("'", "''") -%}
+  {%- set temp_prefix = target_relation.identifier ~ "_dbt_zero_down_tmp_" -%}
+
+  {% for index_dict in index_configs %}
+    {%- set index_config = adapter.parse_index({"columns": index_dict.get("columns", [])}) -%}
+    {%- set canonical_name = risingwave__get_index_name(target_relation.identifier, index_config.columns) -%}
+    {%- set staged_name = risingwave__get_index_name(staged_relation.identifier, index_config.columns) -%}
+    {%- set retired_name = "__dbt_retired_index_{}_{}".format(staged_relation.identifier, loop.index) -%}
+    {%- set canonical_name_literal = canonical_name | replace("'", "''") -%}
+    {%- set result_name = 'zero_downtime_canonical_index_' ~ loop.index -%}
+
+    {# A failed prior run may have left the canonical name on an older temp MV. #}
+    {% call statement(result_name, fetch_result=True) -%}
+      select t.relname as parent_name
+      from pg_index ix
+      join pg_class i on i.oid = ix.indexrelid
+      join pg_class t on t.oid = ix.indrelid
+      join pg_namespace n on n.oid = t.relnamespace
+      where n.nspname = '{{ target_schema_literal }}'
+        and i.relname = '{{ canonical_name_literal }}'
+        and ix.indisprimary = false
+    {%- endcall %}
+
+    {%- set canonical_index = load_result(result_name).table -%}
+    {% if canonical_index is not none and canonical_index.rows | length > 0 %}
+      {%- set canonical_parent = canonical_index.rows[0][0] -%}
+      {% if canonical_parent == target_identifier %}
+        {{ exceptions.raise_compiler_error(
+          "Cannot promote staged index " ~ staged_name ~ " because " ~ canonical_name
+          ~ " is already attached to target relation " ~ target_relation
+        ) }}
+      {% elif not canonical_parent.startswith(temp_prefix) %}
+        {{ exceptions.raise_compiler_error(
+          "Cannot promote staged index " ~ staged_name ~ " because " ~ canonical_name
+          ~ " is owned by unrelated relation " ~ canonical_parent
+        ) }}
+      {% endif %}
+
+      {% call statement('retire_zero_downtime_index_' ~ loop.index) -%}
+        {{ risingwave__get_rename_index_sql(target_relation, canonical_name, retired_name) }}
+      {%- endcall %}
+    {% endif %}
+
+    {% call statement('promote_zero_downtime_index_' ~ loop.index) -%}
+      {{ risingwave__get_rename_index_sql(target_relation, staged_name, canonical_name) }}
+    {%- endcall %}
+  {% endfor %}
+{%- endmacro -%}
+
 {% macro risingwave__drop_relation(relation) -%}
   {% call statement('drop_relation') -%}
     {% if relation.type == 'view' %}
@@ -679,10 +740,19 @@
     select exists (
       select 1
       from rw_catalog.rw_depend
-      join rw_catalog.rw_relations on rw_depend.refobjid = rw_relations.id
-      join rw_catalog.rw_schemas on rw_relations.schema_id = rw_schemas.id
+      join rw_catalog.rw_relations referenced_relation
+        on rw_depend.refobjid = referenced_relation.id
+      join rw_catalog.rw_schemas
+        on referenced_relation.schema_id = rw_schemas.id
+      left join rw_catalog.rw_relations dependent_relation
+        on rw_depend.objid = dependent_relation.id
       where rw_schemas.name = '{{ relation_schema }}'
-        and rw_relations.name = '{{ relation_identifier }}'
+        and referenced_relation.name = '{{ relation_identifier }}'
+        -- Indexes are owned by their parent relation and are dropped with it.
+        and (
+          dependent_relation.relation_type is null
+          or dependent_relation.relation_type != 'index'
+        )
     ) as has_dependents
   {%- endcall %}
 

--- a/dbt/include/risingwave/macros/materializations/materialized_view.sql
+++ b/dbt/include/risingwave/macros/materializations/materialized_view.sql
@@ -71,12 +71,19 @@
       {%- endcall %}
       {{ risingwave__wait_for_background_ddl(temp_relation, 'materialized_view') }}
 
-      {# Step 2: Swap the materialized views #}
+      {# Step 2: Build indexes before cut-over so the new MV is fully indexed at swap time #}
+      {{ create_indexes(temp_relation) }}
+      {{ risingwave__wait_for_background_indexes(temp_relation) }}
+
+      {# Step 3: Swap the materialized views #}
       {% call statement('swap') -%}
         {{ risingwave__swap_materialized_views(old_relation, temp_relation) }}
       {%- endcall %}
 
-      {# Step 3: Conditionally drop the old materialized view (now with temp name) #}
+      {# Step 4: Free canonical names on old indexes and promote the prebuilt indexes #}
+      {{ risingwave__handoff_zero_downtime_indexes(temp_relation, target_relation) }}
+
+      {# Step 5: Conditionally drop the old materialized view (now with temp name) #}
       {% if immediate_cleanup %}
         {{- log("Attempting immediate cleanup of temporary materialized view: " ~ temp_relation) -}}
         {{ risingwave__drop_zero_downtime_temp_relation(temp_relation) }}
@@ -88,9 +95,6 @@
       {# TODO: Should this be before the swap to ensure actual zero downtime #}
       {% set should_revoke = should_revoke(existing_relation=old_relation, full_refresh_mode=true) %}
       {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
-
-      {{ create_indexes(target_relation) }}
-      {{ risingwave__wait_for_background_indexes(target_relation) }}
     {% else %}
       {# Zero downtime disabled - either model config or user flag is missing #}
       {% if model_has_zero_downtime and not user_requested_zero_downtime %}

--- a/docs/zero-downtime-rebuilds.md
+++ b/docs/zero-downtime-rebuilds.md
@@ -27,10 +27,21 @@ This keeps the original object name available during the update.
 When a model already exists and zero downtime is enabled, the adapter:
 
 1. Creates a temporary object with the new definition.
-2. Swaps the temporary object with the original object.
-3. Either preserves or safely drops the old object, depending on `immediate_cleanup` and remaining dependencies.
+2. For an indexed materialized view, builds the configured indexes on the temporary
+   object and waits for their backfill to finish.
+3. Swaps the temporary object with the original object.
+4. Promotes the prebuilt indexes to their canonical dbt names. If a previous index
+   already owns a canonical name, it is renamed and remains attached to the old object.
+5. Either preserves or safely drops the old object, depending on `immediate_cleanup`
+   and remaining dependencies.
 
 Temporary objects use the naming pattern `{original_name}_dbt_zero_down_tmp_{timestamp}`.
+
+RisingWave does not provide an atomic `ALTER INDEX ... SWAP WITH ...` command. The
+adapter instead creates each new index under a unique temporary name, waits for it,
+and performs metadata-only index renames after the materialized-view swap. Queries
+always have a ready index attached to the active materialized view; only the index
+name handoff is non-atomic.
 
 For a supported sink, the adapter instead issues `REPLACE SINK` directly. RisingWave
 creates a replacement sink job, drains the old sink at the cut-over barrier, and exposes
@@ -120,6 +131,11 @@ To try to drop the temporary object immediately after the swap:
 ```
 
 Immediate cleanup is dependency-safe and best-effort. RisingWave `SWAP WITH` keeps existing downstream objects attached to the pre-swap object ID, now renamed to the temporary object. If any dependent object still references that temporary object, the adapter preserves it even when `immediate_cleanup` is `true`; it does not use `CASCADE` for zero-downtime temporary object cleanup.
+
+Indexes owned by a temporary materialized view do not by themselves prevent cleanup.
+RisingWave drops those indexes together with their parent materialized view. They are
+kept while the old materialized view is preserved, so downstream users of the old
+object do not lose its index before the object is safe to remove.
 
 For a chain such as `mv1 -> mv2 -> mv3`, updating only `mv1` can leave `mv2` and `mv3` reading from the preserved temporary `mv1` object. Rebuild dependent models when they should move to the new upstream definition:
 

--- a/tests/e2e/zero_downtime/models/zd_indexed_mv.sql
+++ b/tests/e2e/zero_downtime/models/zd_indexed_mv.sql
@@ -1,0 +1,51 @@
+{% set stage = env_var('DBT_RW_ZERO_DOWNTIME_STAGE', 'initial') %}
+
+{% if stage == 'initial' %}
+  {% set index_configs = [
+      {
+        'columns': ['id'],
+        'include': ['payload'],
+        'distributed_by': ['id']
+      },
+      {
+        'columns': ['deploy_stage'],
+        'include': ['id'],
+        'distributed_by': ['deploy_stage']
+      }
+  ] %}
+{% elif stage == 'changed' %}
+  {% set index_configs = [
+      {
+        'columns': ['id'],
+        'include': ['deploy_stage'],
+        'distributed_by': ['id']
+      },
+      {
+        'columns': ['payload'],
+        'include': ['id'],
+        'distributed_by': ['payload']
+      }
+  ] %}
+{% else %}
+  {{ exceptions.raise_compiler_error("Invalid DBT_RW_ZERO_DOWNTIME_STAGE: " ~ stage) }}
+{% endif %}
+
+{{ config(
+    materialized='materialized_view',
+    indexes=index_configs,
+    background_ddl=true,
+    zero_downtime={
+      'enabled': true,
+      'immediate_cleanup': false
+    }
+) }}
+
+select
+    cast(1 as int) as id,
+    cast('{{ stage }}_indexed_alpha' as varchar) as payload,
+    cast('{{ stage }}' as varchar) as deploy_stage
+union all
+select
+    cast(2 as int) as id,
+    cast('{{ stage }}_indexed_beta' as varchar) as payload,
+    cast('{{ stage }}' as varchar) as deploy_stage

--- a/tests/e2e/zero_downtime/tests/assert_zero_downtime_index.sql
+++ b/tests/e2e/zero_downtime/tests/assert_zero_downtime_index.sql
@@ -1,0 +1,150 @@
+{% set expected_stage = env_var('DBT_RW_ZERO_DOWNTIME_EXPECT_STAGE', 'initial') %}
+{% set expect_preserved_temp = env_var('DBT_RW_ZERO_DOWNTIME_EXPECT_INDEX_TEMP', 'false') == 'true' %}
+{% set indexed_rel = ref('zd_indexed_mv') %}
+
+{% if expected_stage == 'initial' %}
+  {% set expected_indexes = [
+      '__dbt_index_zd_indexed_mv_id',
+      '__dbt_index_zd_indexed_mv_deploy_stage'
+  ] %}
+  {% set stale_index = '__dbt_index_zd_indexed_mv_payload' %}
+{% elif expected_stage == 'changed' %}
+  {% set expected_indexes = [
+      '__dbt_index_zd_indexed_mv_id',
+      '__dbt_index_zd_indexed_mv_payload'
+  ] %}
+  {% set stale_index = '__dbt_index_zd_indexed_mv_deploy_stage' %}
+{% else %}
+  {{ exceptions.raise_compiler_error("Invalid DBT_RW_ZERO_DOWNTIME_EXPECT_STAGE: " ~ expected_stage) }}
+{% endif %}
+
+select 'zd_indexed_mv must be a materialized view' as failure
+where not exists (
+    select 1
+    from rw_catalog.rw_relations r
+    join rw_catalog.rw_schemas s on s.id = r.schema_id
+    where s.name = '{{ indexed_rel.schema }}'
+      and r.name = '{{ indexed_rel.identifier }}'
+      and r.relation_type = 'materialized view'
+)
+
+{% for expected_index in expected_indexes %}
+union all
+
+select '{{ expected_index }} must be attached to zd_indexed_mv' as failure
+where not exists (
+    select 1
+    from pg_index ix
+    join pg_class i on i.oid = ix.indexrelid
+    join pg_class t on t.oid = ix.indrelid
+    join pg_namespace n on n.oid = t.relnamespace
+    where n.nspname = '{{ indexed_rel.schema }}'
+      and t.relname = '{{ indexed_rel.identifier }}'
+      and i.relname = '{{ expected_index }}'
+      and ix.indisprimary = false
+)
+
+union all
+
+select '{{ expected_index }} must not remain attached to a temp MV' as failure
+where exists (
+    select 1
+    from pg_index ix
+    join pg_class i on i.oid = ix.indexrelid
+    join pg_class t on t.oid = ix.indrelid
+    join pg_namespace n on n.oid = t.relnamespace
+    where n.nspname = '{{ indexed_rel.schema }}'
+      and t.relname like '{{ indexed_rel.identifier }}_dbt_zero_down_tmp_%'
+      and i.relname = '{{ expected_index }}'
+      and ix.indisprimary = false
+)
+{% endfor %}
+
+union all
+
+select 'zd_indexed_mv must have exactly two active indexes' as failure
+where (
+    select count(*)
+    from pg_index ix
+    join pg_class t on t.oid = ix.indrelid
+    join pg_namespace n on n.oid = t.relnamespace
+    where n.nspname = '{{ indexed_rel.schema }}'
+      and t.relname = '{{ indexed_rel.identifier }}'
+      and ix.indisprimary = false
+) != 2
+
+union all
+
+select 'staged index names must be promoted after the MV swap' as failure
+where exists (
+    select 1
+    from pg_index ix
+    join pg_class i on i.oid = ix.indexrelid
+    join pg_class t on t.oid = ix.indrelid
+    join pg_namespace n on n.oid = t.relnamespace
+    where n.nspname = '{{ indexed_rel.schema }}'
+      and t.relname = '{{ indexed_rel.identifier }}'
+      and i.relname like '__dbt_index_%_dbt_zero_down_tmp_%'
+      and ix.indisprimary = false
+)
+
+union all
+
+select 'the pre-swap MV and its indexes must remain available before cleanup' as failure
+where {{ 'true' if expect_preserved_temp else 'false' }}
+  and not exists (
+    select 1
+    from pg_index ix
+    join pg_class i on i.oid = ix.indexrelid
+    join pg_class t on t.oid = ix.indrelid
+    join pg_namespace n on n.oid = t.relnamespace
+    where n.nspname = '{{ indexed_rel.schema }}'
+      and t.relname like '{{ indexed_rel.identifier }}_dbt_zero_down_tmp_%'
+      and i.relname = '__dbt_index_zd_indexed_mv_deploy_stage'
+      and ix.indisprimary = false
+)
+
+union all
+
+select 'the replaced id index must be retained under a retired name before cleanup' as failure
+where {{ 'true' if expect_preserved_temp else 'false' }}
+  and not exists (
+    select 1
+    from pg_index ix
+    join pg_class i on i.oid = ix.indexrelid
+    join pg_class t on t.oid = ix.indrelid
+    join pg_namespace n on n.oid = t.relnamespace
+    join pg_attribute a
+      on a.attrelid = t.oid
+     and a.attnum = any(ix.indkey)
+     and array_position(ix.indkey, a.attnum) <= ix.indnkeyatts
+    where n.nspname = '{{ indexed_rel.schema }}'
+      and t.relname like '{{ indexed_rel.identifier }}_dbt_zero_down_tmp_%'
+      and i.relname != '__dbt_index_zd_indexed_mv_id'
+      and a.attname = 'id'
+      and ix.indisprimary = false
+)
+
+union all
+
+select 'the indexed temp MV must be removed by cleanup_temp_objects' as failure
+where {{ 'false' if expect_preserved_temp else 'true' }}
+  and exists (
+    select 1
+    from rw_catalog.rw_relations r
+    join rw_catalog.rw_schemas s on s.id = r.schema_id
+    where s.name = '{{ indexed_rel.schema }}'
+      and r.name like '{{ indexed_rel.identifier }}_dbt_zero_down_tmp_%'
+  )
+
+union all
+
+select '{{ stale_index }} must be removed after cleanup' as failure
+where {{ 'false' if expect_preserved_temp else 'true' }}
+  and exists (
+    select 1
+    from pg_class i
+    join pg_namespace n on n.oid = i.relnamespace
+    where n.nspname = '{{ indexed_rel.schema }}'
+      and i.relname = '{{ stale_index }}'
+  )

--- a/tests/unit/test_materialization_relation_lookup.py
+++ b/tests/unit/test_materialization_relation_lookup.py
@@ -156,6 +156,32 @@ def test_zero_downtime_immediate_cleanup_is_dependency_safe():
     assert "DROP VIEW IF EXISTS {{ obj_relation }} CASCADE" not in adapter_macros
 
 
+def test_zero_downtime_materialized_view_prebuilds_and_promotes_indexes():
+    materialized_view = (MATERIALIZATION_DIR / "materialized_view.sql").read_text()
+    adapter_macros = ADAPTER_MACROS.read_text()
+
+    create_temp = "risingwave__create_materialized_view_with_temp_name(temp_relation, sql)"
+    build_indexes = "create_indexes(temp_relation)"
+    swap = "risingwave__swap_materialized_views(old_relation, temp_relation)"
+    handoff = "risingwave__handoff_zero_downtime_indexes(temp_relation, target_relation)"
+    cleanup = "risingwave__drop_zero_downtime_temp_relation(temp_relation)"
+
+    assert materialized_view.index(create_temp) < materialized_view.index(build_indexes)
+    assert materialized_view.index(build_indexes) < materialized_view.index(swap)
+    assert materialized_view.index(swap) < materialized_view.index(handoff)
+    assert materialized_view.index(handoff) < materialized_view.index(cleanup)
+    assert (
+        "create_indexes(target_relation)"
+        not in materialized_view[materialized_view.index(handoff) :]
+    )
+
+    assert "macro risingwave__get_rename_index_sql" in adapter_macros
+    assert "macro risingwave__handoff_zero_downtime_indexes" in adapter_macros
+    assert "retire_zero_downtime_index_" in adapter_macros
+    assert "promote_zero_downtime_index_" in adapter_macros
+    assert "dependent_relation.relation_type != 'index'" in adapter_macros
+
+
 def test_sink_zero_downtime_uses_replace_sink_for_from_relation():
     sink = (MATERIALIZATION_DIR / "sink.sql").read_text()
     adapter_macros = ADAPTER_MACROS.read_text()


### PR DESCRIPTION
## Summary

- build configured indexes on the temporary materialized view and wait for backfill before `SWAP WITH`
- retire stale canonical index names and promote the prebuilt indexes with metadata-only renames
- treat indexes as owned dependencies during temp cleanup, while continuing to preserve temp MVs with real downstream dependents
- cover unchanged, added, and removed index configurations before and after cleanup

## Why

The current zero-downtime MV path creates indexes only after the swap. That leaves an index rebuild window and, when the old index keeps the canonical name, can strand the old temp MV. Building indexes before cut-over keeps a ready index attached to both the active and replacement MV. RisingWave has no atomic index-name swap, so the adapter performs a retry-safe rename handoff based on catalog ownership.

Alternative to #152.

## Test

- `pytest tests/unit` (`14 passed`)
- isolated `dbt parse --no-partial-parse`
- local RisingWave `latest`:
  - initial `dbt run --full-refresh` and `dbt test`
  - changed zero-downtime `dbt run --vars '{zero_downtime: true}'`
  - pre-cleanup index handoff assertion
  - `dbt run-operation cleanup_temp_objects`
  - post-cleanup `dbt test`
  - repeated same-config indexed MV swap
  - `dbt docs generate`
- `git diff --check`
