### PR TITLE
feat: support backfill_order on materialized views

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Use `enable_serverless_backfill=true` in a model config or profile to enable ser
 
 See [docs/configuration.md](docs/configuration.md) for examples.
 
+### Backfill Order Control
+
+Materialized-view models can use `backfill_order` to render RisingWave's
+`WITH (backfill_order = FIXED(...))` option from a list of dependency edges.
+The model query should continue to use `ref()` or `source()` so dbt records the
+dependency graph.
+
+See [docs/configuration.md](docs/configuration.md#backfill-order) for examples,
+requirements, and RisingWave limitations.
+
 ### Background DDL
 
 `background_ddl=true` lets supported materializations submit background DDL while still preserving dbt semantics by issuing RisingWave `WAIT` before dbt continues.

--- a/dbt/include/risingwave/macros/adapters.sql
+++ b/dbt/include/risingwave/macros/adapters.sql
@@ -57,6 +57,36 @@
   {{- header_parts | join("\n") -}}
 {%- endmacro %}
 
+{% macro risingwave__render_materialized_view_options() -%}
+  {%- set backfill_order = config.get("backfill_order", none) -%}
+  {%- if backfill_order is none -%}
+    {{- return("") -}}
+  {%- endif -%}
+
+  {%- if backfill_order is string
+      or backfill_order is mapping
+      or backfill_order is not sequence
+      or backfill_order | length == 0 -%}
+    {{ exceptions.raise_compiler_error(
+      "`backfill_order` must be a non-empty list of RisingWave FIXED backfill edges, "
+      ~ "for example [`schema.dim -> schema.fact`]."
+    ) }}
+  {%- endif -%}
+
+  {%- set edges = [] -%}
+  {%- for edge in backfill_order -%}
+    {%- if edge is not string or edge | trim == "" -%}
+      {{ exceptions.raise_compiler_error(
+        "Each `backfill_order` entry must be a non-empty string containing a RisingWave "
+        ~ "backfill edge; invalid entry at position " ~ loop.index ~ "."
+      ) }}
+    {%- endif -%}
+    {%- do edges.append(edge | trim) -%}
+  {%- endfor -%}
+
+  with (backfill_order = FIXED({{ edges | join(", ") }}))
+{%- endmacro %}
+
 {% macro risingwave__list_relations_without_caching(schema_relation) %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
     with rw_schema_relations as (
@@ -338,6 +368,7 @@
     {% if contract_config.enforced %}
       {{ get_assert_columns_equivalent(sql) }}
     {%- endif %}
+    {{ risingwave__render_materialized_view_options() }}
   as {{ sql }}
   ;
 {%- endmacro %}
@@ -708,6 +739,7 @@
     {% if contract_config.enforced %}
       {{ get_assert_columns_equivalent(sql) }}
     {%- endif %}
+    {{ risingwave__render_materialized_view_options() }}
   as {{ sql }}
   ;
 {%- endmacro %}

--- a/dbt/include/risingwave/macros/validation.sql
+++ b/dbt/include/risingwave/macros/validation.sql
@@ -126,5 +126,13 @@
     ) }}
   {%- endif -%}
 
+  {%- if materialization not in ['materialized_view', 'materializedview'] and config.get('backfill_order', none) is not none -%}
+    {{ risingwave__validation_report(
+      'RW010',
+      "`backfill_order` is only used by materialized-view materializations. It is ignored by `"
+      ~ materialization ~ "`."
+    ) }}
+  {%- endif -%}
+
   {{ risingwave__validate_ignored_index_options(materialization) }}
 {%- endmacro %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -180,6 +180,82 @@ models:
 
 This emits `set enable_serverless_backfill = true;` before the model DDL runs.
 
+### Backfill Order
+
+RisingWave 2.5 and later can control the initial backfill sequence of upstream
+relations for a materialized view. Configure `backfill_order` as a non-empty
+list of fixed dependency edges:
+
+```sql
+{{ config(
+    materialized='materialized_view',
+    backfill_order=[
+        'analytics.user_history -> analytics.user_events',
+        'analytics.account_history -> analytics.user_events'
+    ]
+) }}
+
+select ...
+from {{ ref('user_events') }}
+join {{ ref('user_history') }} using (user_id)
+join {{ ref('account_history') }} using (account_id)
+```
+
+The adapter renders the list in the materialized-view DDL:
+
+```sql
+create materialized view ...
+with (
+    backfill_order = FIXED(
+        analytics.user_history -> analytics.user_events,
+        analytics.account_history -> analytics.user_events
+    )
+)
+as ...
+```
+
+Each list item is inserted as one RisingWave `FIXED` edge. The adapter validates
+the config shape, while RisingWave validates relation usage, cycles, and the
+resulting graph. Use schema-qualified relation names when upstream relations are
+outside the session search path. Keep `ref()` or `source()` calls in the model
+query so dbt records the dependency graph.
+
+Do not put `ref()` or `source()` directly inside the `backfill_order` config.
+dbt captures config values during parsing, when those functions do not yet
+produce the final upstream relation names. If all upstream relations share the
+model's target schema, you can build portable quoted edges from `this.schema`:
+
+```sql
+{% set edge_schema = adapter.quote(this.schema) %}
+
+{{ config(
+    materialized='materialized_view',
+    backfill_order=[
+        edge_schema ~ '."user_history" -> ' ~ edge_schema ~ '."user_events"'
+    ]
+) }}
+```
+
+Current constraints:
+
+- `backfill_order` is a RisingWave technical-preview feature supported only for
+  materialized views. Cross-database edges are not supported.
+- The option takes effect only when dbt issues `CREATE MATERIALIZED VIEW`, such
+  as on the first run, `--full-refresh`, or a zero-downtime rebuild. Changing
+  the config alone does not alter an existing materialized view.
+- RisingWave can reject a base-table edge when index selection rewrites that
+  scan to an index. Until
+  [risingwavelabs/risingwave#25755](https://github.com/risingwavelabs/risingwave/issues/25755)
+  is fixed, set `enable_index_selection=false` on affected models.
+- RisingWave 2.5 through 2.7 do not restore a fixed order after a background DDL
+  job restarts. Recovery support was added in RisingWave 2.8 by
+  [#24539](https://github.com/risingwavelabs/risingwave/pull/24539) and
+  [#24590](https://github.com/risingwavelabs/risingwave/pull/24590).
+
+See RisingWave's
+[`CREATE MATERIALIZED VIEW` documentation](https://docs.risingwave.com/sql/commands/sql-create-mv#backfill-behavior-and-controls)
+for edge semantics and progress-inspection commands.
+
 ### Background DDL
 
 `dbt-risingwave` supports opting into RisingWave background DDL for these paths:

--- a/tests/e2e/basic_models/models/backfill_dimension.sql
+++ b/tests/e2e/basic_models/models/backfill_dimension.sql
@@ -1,0 +1,5 @@
+{{ config(materialized='table') }}
+
+select 1 as id, 'first'::varchar as category
+union all
+select 2 as id, 'second'::varchar as category

--- a/tests/e2e/basic_models/models/ordered_events_mv.sql
+++ b/tests/e2e/basic_models/models/ordered_events_mv.sql
@@ -1,0 +1,15 @@
+{% set edge_schema = adapter.quote(this.schema) %}
+
+{{ config(
+    materialized='materialized_view',
+    backfill_order=[
+        edge_schema ~ '."base_table" -> ' ~ edge_schema ~ '."backfill_dimension"'
+    ]
+) }}
+
+select
+    events.id,
+    events.payload,
+    dimensions.category
+from {{ ref('base_table') }} as events
+join {{ ref('backfill_dimension') }} as dimensions using (id)

--- a/tests/e2e/basic_models/tests/assert_core_materializations.sql
+++ b/tests/e2e/basic_models/tests/assert_core_materializations.sql
@@ -34,6 +34,18 @@ where not exists (
 
 union all
 
+select 'ordered_events_mv must be a materialized view' as failure
+where not exists (
+    select 1
+    from rw_relations
+    join rw_schemas on schema_id = rw_schemas.id
+    where rw_schemas.name = '{{ target.schema }}'
+      and rw_relations.name = 'ordered_events_mv'
+      and rw_relations.relation_type = 'materialized view'
+)
+
+union all
+
 select 'base_table has unexpected row count' as failure
 where (select count(*) from {{ ref('base_table') }}) != 2
 
@@ -93,4 +105,25 @@ select 'events_mv missing beta row' as failure
 where not exists (
     select 1 from {{ ref('events_mv') }}
     where id = 2 and payload = 'beta_view_mv'
+)
+
+union all
+
+select 'ordered_events_mv has unexpected row count' as failure
+where (select count(*) from {{ ref('ordered_events_mv') }}) != 2
+
+union all
+
+select 'ordered_events_mv missing first row' as failure
+where not exists (
+    select 1 from {{ ref('ordered_events_mv') }}
+    where id = 1 and payload = 'alpha' and category = 'first'
+)
+
+union all
+
+select 'ordered_events_mv missing second row' as failure
+where not exists (
+    select 1 from {{ ref('ordered_events_mv') }}
+    where id = 2 and payload = 'beta' and category = 'second'
 )

--- a/tests/unit/test_materialization_relation_lookup.py
+++ b/tests/unit/test_materialization_relation_lookup.py
@@ -3,6 +3,9 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+from dbt_common.clients.jinja import CallableMacroGenerator, MacroReturn
+
 
 MATERIALIZATION_DIR = (
     Path(__file__).resolve().parents[2]
@@ -109,8 +112,75 @@ def test_adapter_validation_rules_are_documented_in_macro():
     assert "`indexes[].unique` is a PostgreSQL adapter option" in validation_macros
     assert "`indexes[].type` is a PostgreSQL adapter option" in validation_macros
     assert "`zero_downtime` is only supported" in validation_macros
+    assert (
+        "`backfill_order` is only used by materialized-view materializations" in validation_macros
+    )
     assert "RW001" in validation_macros
     assert "RW009" in validation_macros
+    assert "RW010" in validation_macros
+
+
+def test_backfill_order_renders_fixed_materialized_view_option():
+    rendered = render_adapter_macro(
+        "risingwave__render_materialized_view_options",
+        {
+            "backfill_order": [
+                " public.dim -> public.fact ",
+                '"Sales Schema"."History" -> "Sales Schema"."Events"',
+            ]
+        },
+    )
+
+    assert rendered == (
+        "with (backfill_order = FIXED("
+        "public.dim -> public.fact, "
+        '"Sales Schema"."History" -> "Sales Schema"."Events"))'
+    )
+
+
+def test_unset_backfill_order_does_not_render_materialized_view_options():
+    assert (
+        render_adapter_macro(
+            "risingwave__render_materialized_view_options",
+            {},
+        )
+        == ""
+    )
+
+
+@pytest.mark.parametrize(
+    "backfill_order",
+    [
+        [],
+        "public.dim -> public.fact",
+        {"dim": "fact"},
+        ["public.dim -> public.fact", 42],
+        ["public.dim -> public.fact", "  "],
+    ],
+)
+def test_backfill_order_rejects_invalid_config(backfill_order):
+    with pytest.raises(ValueError, match="backfill_order"):
+        render_adapter_macro(
+            "risingwave__render_materialized_view_options",
+            {"backfill_order": backfill_order},
+        )
+
+
+def test_backfill_order_is_rendered_for_normal_and_zero_downtime_mv_creation():
+    adapter_macros = ADAPTER_MACROS.read_text()
+
+    for macro_name in (
+        "risingwave__create_materialized_view_as",
+        "risingwave__create_materialized_view_with_temp_name",
+    ):
+        macro_start = adapter_macros.index(f"macro {macro_name}")
+        macro_end = adapter_macros.index("endmacro", macro_start)
+        macro = adapter_macros[macro_start:macro_end]
+
+        assert macro.count("risingwave__render_materialized_view_options()") == 1
+        assert macro.index("risingwave__render_materialized_view_options()") < macro.index(
+            "as {{ sql }}"
+        )
 
 
 def test_adapter_validation_is_wired_into_materializations():
@@ -276,3 +346,21 @@ def load_local_connections_module():
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def render_adapter_macro(name, config, *args):
+    def dbt_return(value):
+        raise MacroReturn(value)
+
+    def raise_compiler_error(message):
+        raise ValueError(message)
+
+    macro = SimpleNamespace(name=name, macro_sql=ADAPTER_MACROS.read_text())
+    context = {
+        "config": config,
+        "exceptions": SimpleNamespace(
+            raise_compiler_error=raise_compiler_error,
+        ),
+        "return": dbt_return,
+    }
+    return CallableMacroGenerator(macro, context)(*args)


### PR DESCRIPTION
## Summary

- add a `backfill_order` model config that accepts a non-empty list of RisingWave `FIXED` dependency edges
- render `WITH (backfill_order = FIXED(...))` for both normal materialized-view creation and zero-downtime temporary materialized views
- validate malformed configs and warn when `backfill_order` is used by another materialization
- document RisingWave version requirements, index-selection and recovery caveats, and dbt's parse-time behavior for `ref()`/`source()` inside config values
- add an end-to-end model that creates a schema-qualified, quoted fixed-order materialized view and validates its rows

Example:

```sql
{{ config(
    materialized='materialized_view',
    backfill_order=[
        'analytics.user_history -> analytics.user_events',
        'analytics.account_history -> analytics.user_events'
    ]
) }}
```

RisingWave remains responsible for validating edge syntax, relation usage, cycles, and the resulting graph.

## Validation

- `python -m pytest -q tests/unit` — 23 passed
- `dbt parse --no-partial-parse` for `tests/e2e/basic_models`
- isolated RisingWave 3.0.1: `dbt run --full-refresh` — 5/5 models passed
- isolated RisingWave 3.0.1: `dbt test` — 1/1 data test passed
- isolated RisingWave 3.0.1: `dbt docs generate`
- isolated RisingWave 3.0.1: exercised zero-downtime temp MV creation, swap, and cleanup; the temp MV DDL retained the configured `FIXED(...)` clause
- `git diff --check`

Closes #158
